### PR TITLE
[18.06] Update containerd to v1.1.1-rc.2

### DIFF
--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-CONTAINERD_COMMIT=cbef57047e900aeb2bafe7a634919bec13f4a2a5 # v1.1.1-rc.1
+CONTAINERD_COMMIT=e5fb877b9f6c14b15f48643735a8c9764a7319d3 # v1.1.1-rc.2
 
 install_containerd() {
 	echo "Install containerd version $CONTAINERD_COMMIT"


### PR DESCRIPTION
cherry-pick of https://github.com/moby/moby/pull/37357/commits/735517928b3c0a9dabdc087b1b2f366d72df3f4e (https://github.com/moby/moby/pull/37357) for 18.06


ping @dmcgowan @tonistiigi 