### PR TITLE
[18.06] Update Microsoft/go-winio to 0.4.8

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -1,7 +1,7 @@
 # the following lines are in sorted order, FYI
 github.com/Azure/go-ansiterm d6e3b3328b783f23731bc4d058875b0371ff8109
 github.com/Microsoft/hcsshim v0.6.11
-github.com/Microsoft/go-winio v0.4.7
+github.com/Microsoft/go-winio v0.4.8
 github.com/docker/libtrust 9cbd2a1374f46905c68a4eb3694a130610adc62a
 github.com/go-check/check 4ed411733c5785b40214c70bce814c3a3a689609 https://github.com/cpuguy83/check.git
 github.com/golang/gddo 9b12a26f3fbd7397dee4e20939ddca719d840d2a


### PR DESCRIPTION
Fixes named pipe support for hyper-v isolated containers

cherry picked from commit 74095588baa0693a2c07bd05c001c42830f82ed3 (https://github.com/moby/moby/pull/37364) - no conflicts
