### PR TITLE
[18.06] Register OCI image media types

### DIFF
--- a/distribution/oci.go
+++ b/distribution/oci.go
@@ -1,0 +1,45 @@
+package distribution
+
+import (
+	"fmt"
+
+	"github.com/docker/distribution"
+	"github.com/docker/distribution/manifest/manifestlist"
+	"github.com/docker/distribution/manifest/schema2"
+	digest "github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+func init() {
+	// TODO: Remove this registration if distribution is included with OCI support
+
+	ocischemaFunc := func(b []byte) (distribution.Manifest, distribution.Descriptor, error) {
+		m := new(schema2.DeserializedManifest)
+		err := m.UnmarshalJSON(b)
+		if err != nil {
+			return nil, distribution.Descriptor{}, err
+		}
+
+		dgst := digest.FromBytes(b)
+		return m, distribution.Descriptor{Digest: dgst, Size: int64(len(b)), MediaType: ocispec.MediaTypeImageManifest}, err
+	}
+	err := distribution.RegisterManifestSchema(ocispec.MediaTypeImageManifest, ocischemaFunc)
+	if err != nil {
+		panic(fmt.Sprintf("Unable to register manifest: %s", err))
+	}
+
+	manifestListFunc := func(b []byte) (distribution.Manifest, distribution.Descriptor, error) {
+		m := new(manifestlist.DeserializedManifestList)
+		err := m.UnmarshalJSON(b)
+		if err != nil {
+			return nil, distribution.Descriptor{}, err
+		}
+
+		dgst := digest.FromBytes(b)
+		return m, distribution.Descriptor{Digest: dgst, Size: int64(len(b)), MediaType: ocispec.MediaTypeImageIndex}, err
+	}
+	err = distribution.RegisterManifestSchema(ocispec.MediaTypeImageIndex, manifestListFunc)
+	if err != nil {
+		panic(fmt.Sprintf("Unable to register manifest: %s", err))
+	}
+}

--- a/distribution/registry.go
+++ b/distribution/registry.go
@@ -17,11 +17,13 @@ import (
 	"github.com/docker/docker/dockerversion"
 	"github.com/docker/docker/registry"
 	"github.com/docker/go-connections/sockets"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // ImageTypes represents the schema2 config types for images
 var ImageTypes = []string{
 	schema2.MediaTypeImageConfig,
+	ocispec.MediaTypeImageConfig,
 	// Handle unexpected values from https://github.com/docker/distribution/issues/1621
 	// (see also https://github.com/docker/docker/issues/22378,
 	// https://github.com/docker/docker/issues/30083)


### PR DESCRIPTION
OCI types are backwards compatible with Docker manifest types, however the media types must be registered.

cherry picked from commit c4f0515837b834ec66ec463d92a32015062a0804 (https://github.com/moby/moby/pull/37359); no conflicts. cherry-pick was clean
