### PR TITLE
[18.06] api: Change Platform field back to string (temporary workaround)

### DIFF
--- a/api/server/backend/build/backend.go
+++ b/api/server/backend/build/backend.go
@@ -73,7 +73,7 @@ func (b *Backend) Build(ctx context.Context, config backend.BuildConfig) (string
 			return "", err
 		}
 		if config.ProgressWriter.AuxFormatter != nil {
-			if err = config.ProgressWriter.AuxFormatter.Emit(types.BuildResult{ID: imageID}); err != nil {
+			if err = config.ProgressWriter.AuxFormatter.Emit("moby.image.id", types.BuildResult{ID: imageID}); err != nil {
 				return "", err
 			}
 		}

--- a/api/server/router/build/build_routes.go
+++ b/api/server/router/build/build_routes.go
@@ -243,6 +243,10 @@ func (br *buildRouter) postBuild(ctx context.Context, w http.ResponseWriter, r *
 		return errdefs.InvalidParameter(errors.New("squash is only supported with experimental mode"))
 	}
 
+	if buildOptions.Version == types.BuilderBuildKit && !br.daemon.HasExperimental() {
+		return errdefs.InvalidParameter(errors.New("buildkit is only supported with experimental mode"))
+	}
+
 	out := io.Writer(output)
 	if buildOptions.SuppressOutput {
 		out = notVerboseBuffer
@@ -253,10 +257,6 @@ func (br *buildRouter) postBuild(ctx context.Context, w http.ResponseWriter, r *
 	createProgressReader := func(in io.ReadCloser) io.ReadCloser {
 		progressOutput := streamformatter.NewJSONProgressOutput(out, true)
 		return progress.NewProgressReader(in, progressOutput, r.ContentLength, "Downloading context", buildOptions.RemoteContext)
-	}
-
-	if buildOptions.Version == types.BuilderBuildKit && !br.daemon.HasExperimental() {
-		return errdefs.InvalidParameter(errors.New("buildkit is only supported with experimental mode"))
 	}
 
 	wantAux := versions.GreaterThanOrEqualTo(version, "1.30")

--- a/api/server/router/build/build_routes.go
+++ b/api/server/router/build/build_routes.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/containerd/containerd/platforms"
 	"github.com/docker/docker/api/server/httputils"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"
@@ -24,8 +23,7 @@ import (
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/progress"
 	"github.com/docker/docker/pkg/streamformatter"
-	"github.com/docker/docker/pkg/system"
-	"github.com/docker/go-units"
+	units "github.com/docker/go-units"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -72,17 +70,7 @@ func newImageBuildOptions(ctx context.Context, r *http.Request) (*types.ImageBui
 	options.Target = r.FormValue("target")
 	options.RemoteContext = r.FormValue("remote")
 	if versions.GreaterThanOrEqualTo(version, "1.32") {
-		apiPlatform := r.FormValue("platform")
-		if apiPlatform != "" {
-			sp, err := platforms.Parse(apiPlatform)
-			if err != nil {
-				return nil, err
-			}
-			if err := system.ValidatePlatform(sp); err != nil {
-				return nil, err
-			}
-			options.Platform = &sp
-		}
+		options.Platform = r.FormValue("platform")
 	}
 
 	if r.Form.Get("shmsize") != "" {

--- a/api/types/client.go
+++ b/api/types/client.go
@@ -7,8 +7,7 @@ import (
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
-	"github.com/docker/go-units"
-	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	units "github.com/docker/go-units"
 )
 
 // CheckpointCreateOptions holds parameters to create a checkpoint from a container
@@ -181,7 +180,7 @@ type ImageBuildOptions struct {
 	ExtraHosts  []string // List of extra hosts
 	Target      string
 	SessionID   string
-	Platform    *specs.Platform
+	Platform    string
 	// Version specifies the version of the unerlying builder to use
 	Version BuilderVersion
 	// BuildID is an optional identifier that can be passed together with the

--- a/builder/builder-next/builder.go
+++ b/builder/builder-next/builder.go
@@ -2,7 +2,6 @@ package buildkit
 
 import (
 	"context"
-	"encoding/json"
 	"io"
 	"strings"
 	"sync"
@@ -14,7 +13,7 @@ import (
 	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/builder"
 	"github.com/docker/docker/daemon/images"
-	"github.com/docker/docker/pkg/jsonmessage"
+	"github.com/docker/docker/pkg/streamformatter"
 	controlapi "github.com/moby/buildkit/api/services/control"
 	"github.com/moby/buildkit/control"
 	"github.com/moby/buildkit/identity"
@@ -228,6 +227,8 @@ func (b *Builder) Build(ctx context.Context, opt backend.BuildConfig) (*builder.
 		Session:       opt.Options.SessionID,
 	}
 
+	aux := streamformatter.AuxFormatter{opt.ProgressWriter.Output}
+
 	eg, ctx := errgroup.WithContext(ctx)
 
 	eg.Go(func() error {
@@ -240,7 +241,7 @@ func (b *Builder) Build(ctx context.Context, opt backend.BuildConfig) (*builder.
 			return errors.Errorf("missing image id")
 		}
 		out.ImageID = id
-		return nil
+		return aux.Emit("moby.image.id", types.BuildResult{ID: id})
 	})
 
 	ch := make(chan *controlapi.StatusResponse)
@@ -258,24 +259,8 @@ func (b *Builder) Build(ctx context.Context, opt backend.BuildConfig) (*builder.
 			if err != nil {
 				return err
 			}
-
-			auxJSONBytes, err := json.Marshal(dt)
-			if err != nil {
+			if err := aux.Emit("moby.buildkit.trace", dt); err != nil {
 				return err
-			}
-			auxJSON := new(json.RawMessage)
-			*auxJSON = auxJSONBytes
-			msgJSON, err := json.Marshal(&jsonmessage.JSONMessage{ID: "moby.buildkit.trace", Aux: auxJSON})
-			if err != nil {
-				return err
-			}
-			msgJSON = append(msgJSON, []byte("\r\n")...)
-			n, err := opt.ProgressWriter.Output.Write(msgJSON)
-			if err != nil {
-				return err
-			}
-			if n != len(msgJSON) {
-				return io.ErrShortWrite
 			}
 		}
 		return nil

--- a/builder/dockerfile/builder.go
+++ b/builder/dockerfile/builder.go
@@ -257,7 +257,7 @@ func emitImageID(aux *streamformatter.AuxFormatter, state *dispatchState) error 
 	if aux == nil || state.imageID == "" {
 		return nil
 	}
-	return aux.Emit(types.BuildResult{ID: state.imageID})
+	return aux.Emit("", types.BuildResult{ID: state.imageID})
 }
 
 func processMetaArg(meta instructions.ArgCommand, shlex *shell.Lex, args *BuildArgs) error {

--- a/builder/dockerfile/copy.go
+++ b/builder/dockerfile/copy.go
@@ -87,7 +87,7 @@ func copierFromDispatchRequest(req dispatchRequest, download sourceDownloader, i
 		pathCache:   req.builder.pathCache,
 		download:    download,
 		imageSource: imageSource,
-		platform:    req.builder.options.Platform,
+		platform:    req.builder.platform,
 	}
 }
 

--- a/builder/dockerfile/dispatchers.go
+++ b/builder/dockerfile/dispatchers.go
@@ -146,7 +146,7 @@ func (d *dispatchRequest) getImageMount(imageRefOrID string) (*imageMount, error
 		imageRefOrID = stage.Image
 		localOnly = true
 	}
-	return d.builder.imageSources.Get(imageRefOrID, localOnly, d.builder.options.Platform)
+	return d.builder.imageSources.Get(imageRefOrID, localOnly, d.builder.platform)
 }
 
 // FROM [--platform=platform] imagename[:tag | @digest] [AS build-stage-name]
@@ -238,7 +238,7 @@ func (d *dispatchRequest) getImageOrStage(name string, platform *specs.Platform)
 	}
 
 	if platform == nil {
-		platform = d.builder.options.Platform
+		platform = d.builder.platform
 	}
 
 	// Windows cannot support a container with no base image unless it is LCOW.

--- a/builder/dockerfile/dispatchers_test.go
+++ b/builder/dockerfile/dispatchers_test.go
@@ -6,7 +6,6 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/containerd/containerd/platforms"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/api/types/container"
@@ -23,8 +22,7 @@ import (
 
 func newBuilderWithMockBackend() *Builder {
 	mockBackend := &MockBackend{}
-	defaultPlatform := platforms.DefaultSpec()
-	opts := &types.ImageBuildOptions{Platform: &defaultPlatform}
+	opts := &types.ImageBuildOptions{}
 	ctx := context.Background()
 	b := &Builder{
 		options:       opts,
@@ -116,7 +114,7 @@ func TestFromScratch(t *testing.T) {
 	err := initializeStage(sb, cmd)
 
 	if runtime.GOOS == "windows" && !system.LCOWSupported() {
-		assert.Check(t, is.Error(err, "Windows does not support FROM scratch"))
+		assert.Check(t, is.Error(err, "Linux containers are not supported on this system"))
 		return
 	}
 

--- a/pkg/streamformatter/streamformatter.go
+++ b/pkg/streamformatter/streamformatter.go
@@ -139,14 +139,14 @@ type AuxFormatter struct {
 }
 
 // Emit emits the given interface as an aux progress message
-func (sf *AuxFormatter) Emit(aux interface{}) error {
+func (sf *AuxFormatter) Emit(id string, aux interface{}) error {
 	auxJSONBytes, err := json.Marshal(aux)
 	if err != nil {
 		return err
 	}
 	auxJSON := new(json.RawMessage)
 	*auxJSON = auxJSONBytes
-	msgJSON, err := json.Marshal(&jsonmessage.JSONMessage{Aux: auxJSON})
+	msgJSON, err := json.Marshal(&jsonmessage.JSONMessage{ID: id, Aux: auxJSON})
 	if err != nil {
 		return err
 	}

--- a/pkg/streamformatter/streamformatter_test.go
+++ b/pkg/streamformatter/streamformatter_test.go
@@ -106,7 +106,7 @@ func TestAuxFormatterEmit(t *testing.T) {
 	sampleAux := &struct {
 		Data string
 	}{"Additional data"}
-	err := aux.Emit(sampleAux)
+	err := aux.Emit("", sampleAux)
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(`{"aux":{"Data":"Additional data"}}`+streamNewline, b.String()))
 }


### PR DESCRIPTION
This partially reverts https://github.com/moby/moby/pull/37350

Although specs.Platform is desirable in the API, there is more work
to be done on helper functions, namely containerd's platforms.Parse
that assumes the default platform of the Go runtime.

That prevents a client to use the recommended Parse function to
retrieve a specs.Platform object.

With this change, no parsing is expected from the client.

Signed-off-by: Tibor Vass <tibor@docker.com>
(cherry picked from commit facad557440a0c955beb615495b8d0175f25e4e3)
Signed-off-by: Tibor Vass <tibor@docker.com>

Only a simple import path conflict:
```diff
diff --cc builder/builder-next/builder.go
index 5a82cddf44,b1d31a5225..0000000000
--- a/builder/builder-next/builder.go
+++ b/builder/builder-next/builder.go
@@@ -14,7 -13,8 +14,12 @@@ import
        "github.com/docker/docker/api/types/backend"
        "github.com/docker/docker/builder"
        "github.com/docker/docker/daemon/images"
++<<<<<<< HEAD
 +      "github.com/docker/docker/pkg/jsonmessage"
++=======
+       "github.com/docker/docker/pkg/streamformatter"
+       "github.com/docker/docker/pkg/system"
++>>>>>>> facad55744... api: Change Platform field back to string (temporary workaround)
        controlapi "github.com/moby/buildkit/api/services/control"
        "github.com/moby/buildkit/control"
        "github.com/moby/buildkit/identity"

```