### PR TITLE
[18.06] vendor: update buildkit to 9acf51e491

### DIFF
--- a/builder/builder-next/adapters/containerimage/pull.go
+++ b/builder/builder-next/adapters/containerimage/pull.go
@@ -644,7 +644,7 @@ func showProgress(ctx context.Context, ongoing *jobs, cs content.Store, pw progr
 // featured.
 type jobs struct {
 	name     string
-	added    map[digest.Digest]job
+	added    map[digest.Digest]*job
 	mu       sync.Mutex
 	resolved bool
 }
@@ -658,7 +658,7 @@ type job struct {
 func newJobs(name string) *jobs {
 	return &jobs{
 		name:  name,
-		added: make(map[digest.Digest]job),
+		added: make(map[digest.Digest]*job),
 	}
 }
 
@@ -669,17 +669,17 @@ func (j *jobs) add(desc ocispec.Descriptor) {
 	if _, ok := j.added[desc.Digest]; ok {
 		return
 	}
-	j.added[desc.Digest] = job{
+	j.added[desc.Digest] = &job{
 		Descriptor: desc,
 		started:    time.Now(),
 	}
 }
 
-func (j *jobs) jobs() []job {
+func (j *jobs) jobs() []*job {
 	j.mu.Lock()
 	defer j.mu.Unlock()
 
-	descs := make([]job, 0, len(j.added))
+	descs := make([]*job, 0, len(j.added))
 	for _, j := range j.added {
 		descs = append(descs, j)
 	}

--- a/vendor.conf
+++ b/vendor.conf
@@ -26,7 +26,7 @@ github.com/imdario/mergo v0.3.5
 golang.org/x/sync fd80eb99c8f653c847d294a001bdf2a3a6f768f5
 
 # buildkit
-github.com/moby/buildkit cce2080ddbe4698912f2290892b247c83627efa8
+github.com/moby/buildkit 9acf51e49185b348608e0096b2903dd72907adcb
 github.com/tonistiigi/fsutil 8abad97ee3969cdf5e9c367f46adba2c212b3ddb
 github.com/grpc-ecosystem/grpc-opentracing 8e809c8a86450a29b90dcc9efbf062d0fe6d9746
 github.com/opentracing/opentracing-go 1361b9cd60be79c4c3a7fa9841b3c132e40066a7

--- a/vendor/github.com/moby/buildkit/README.md
+++ b/vendor/github.com/moby/buildkit/README.md
@@ -138,11 +138,11 @@ docker inspect myimage
 
 ##### Building a Dockerfile using [external frontend](https://hub.docker.com/r/tonistiigi/dockerfile/tags/):
 
-During development, an external version of the Dockerfile frontend is pushed to https://hub.docker.com/r/tonistiigi/dockerfile that can be used with the gateway frontend. The source for the external frontend is currently located in `./frontend/dockerfile/cmd/dockerfile-frontend` but will move out of this repository in the future ([#163](https://github.com/moby/buildkit/issues/163)).
+During development, an external version of the Dockerfile frontend is pushed to https://hub.docker.com/r/tonistiigi/dockerfile that can be used with the gateway frontend. The source for the external frontend is currently located in `./frontend/dockerfile/cmd/dockerfile-frontend` but will move out of this repository in the future ([#163](https://github.com/moby/buildkit/issues/163)). For automatic build from master branch of this repository `tonistiigi/dockerfile:master` image can be used.
 
 ```
-buildctl build --frontend=gateway.v0 --frontend-opt=source=tonistiigi/dockerfile:v0 --local context=. --local dockerfile=.
-buildctl build --frontend gateway.v0 --frontend-opt=source=tonistiigi/dockerfile:v0 --frontend-opt=context=git://github.com/moby/moby --frontend-opt build-arg:APT_MIRROR=cdn-fastly.deb.debian.org
+buildctl build --frontend=gateway.v0 --frontend-opt=source=tonistiigi/dockerfile --local context=. --local dockerfile=.
+buildctl build --frontend gateway.v0 --frontend-opt=source=tonistiigi/dockerfile --frontend-opt=context=git://github.com/moby/moby --frontend-opt build-arg:APT_MIRROR=cdn-fastly.deb.debian.org
 ````
 
 ### Exporters

--- a/vendor/github.com/moby/buildkit/cache/remotecache/export.go
+++ b/vendor/github.com/moby/buildkit/cache/remotecache/export.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/images"
-	"github.com/docker/distribution/manifest"
 	v1 "github.com/moby/buildkit/cache/remotecache/v1"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/solver"
@@ -17,6 +16,7 @@ import (
 	"github.com/moby/buildkit/util/progress"
 	"github.com/moby/buildkit/util/push"
 	digest "github.com/opencontainers/go-digest"
+	specs "github.com/opencontainers/image-spec/specs-go"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
@@ -46,7 +46,9 @@ func (ce *CacheExporter) Finalize(ctx context.Context, cc *v1.CacheChains, targe
 
 	// own type because oci type can't be pushed and docker type doesn't have annotations
 	type manifestList struct {
-		manifest.Versioned
+		specs.Versioned
+
+		MediaType string `json:"mediaType,omitempty"`
 
 		// Manifests references platform specific manifests.
 		Manifests []ocispec.Descriptor `json:"manifests"`

--- a/vendor/github.com/moby/buildkit/executor/oci/user.go
+++ b/vendor/github.com/moby/buildkit/executor/oci/user.go
@@ -2,27 +2,31 @@ package oci
 
 import (
 	"context"
+	"errors"
 	"os"
 	"strconv"
 	"strings"
 
+	"github.com/containerd/containerd/containers"
+	containerdoci "github.com/containerd/containerd/oci"
 	"github.com/containerd/continuity/fs"
 	"github.com/opencontainers/runc/libcontainer/user"
+	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
-func GetUser(ctx context.Context, root, username string) (uint32, uint32, error) {
+func GetUser(ctx context.Context, root, username string) (uint32, uint32, []uint32, error) {
 	// fast path from uid/gid
-	if uid, gid, err := ParseUser(username); err == nil {
-		return uid, gid, nil
+	if uid, gid, err := ParseUIDGID(username); err == nil {
+		return uid, gid, nil, nil
 	}
 
 	passwdPath, err := user.GetPasswdPath()
 	if err != nil {
-		return 0, 0, err
+		return 0, 0, nil, err
 	}
 	groupPath, err := user.GetGroupPath()
 	if err != nil {
-		return 0, 0, err
+		return 0, 0, nil, err
 	}
 	passwdFile, err := openUserFile(root, passwdPath)
 	if err == nil {
@@ -35,33 +39,29 @@ func GetUser(ctx context.Context, root, username string) (uint32, uint32, error)
 
 	execUser, err := user.GetExecUser(username, nil, passwdFile, groupFile)
 	if err != nil {
-		return 0, 0, err
+		return 0, 0, nil, err
 	}
-
-	return uint32(execUser.Uid), uint32(execUser.Gid), nil
+	var sgids []uint32
+	for _, g := range execUser.Sgids {
+		sgids = append(sgids, uint32(g))
+	}
+	return uint32(execUser.Uid), uint32(execUser.Gid), sgids, nil
 }
 
-func ParseUser(str string) (uid uint32, gid uint32, err error) {
+// ParseUIDGID takes the fast path to parse UID and GID if and only if they are both provided
+func ParseUIDGID(str string) (uid uint32, gid uint32, err error) {
 	if str == "" {
 		return 0, 0, nil
 	}
 	parts := strings.SplitN(str, ":", 2)
-	for i, v := range parts {
-		switch i {
-		case 0:
-			uid, err = parseUID(v)
-			if err != nil {
-				return 0, 0, err
-			}
-			if len(parts) == 1 {
-				gid = uid
-			}
-		case 1:
-			gid, err = parseUID(v)
-			if err != nil {
-				return 0, 0, err
-			}
-		}
+	if len(parts) == 1 {
+		return 0, 0, errors.New("groups ID is not provided")
+	}
+	if uid, err = parseUID(parts[0]); err != nil {
+		return 0, 0, err
+	}
+	if gid, err = parseUID(parts[1]); err != nil {
+		return 0, 0, err
 	}
 	return
 }
@@ -83,4 +83,25 @@ func parseUID(str string) (uint32, error) {
 		return 0, err
 	}
 	return uint32(uid), nil
+}
+
+// WithUIDGID allows the UID and GID for the Process to be set
+// FIXME: This is a temporeray fix for the missing supplementary GIDs from containerd
+// once the PR in containerd is merged we should remove this function.
+func WithUIDGID(uid, gid uint32, sgids []uint32) containerdoci.SpecOpts {
+	return func(_ context.Context, _ containerdoci.Client, _ *containers.Container, s *containerdoci.Spec) error {
+		setProcess(s)
+		s.Process.User.UID = uid
+		s.Process.User.GID = gid
+		s.Process.User.AdditionalGids = sgids
+		return nil
+	}
+}
+
+// setProcess sets Process to empty if unset
+// FIXME: Same on this one. Need to be removed after containerd fix merged
+func setProcess(s *containerdoci.Spec) {
+	if s.Process == nil {
+		s.Process = &specs.Process{}
+	}
 }

--- a/vendor/github.com/moby/buildkit/executor/runcexecutor/executor.go
+++ b/vendor/github.com/moby/buildkit/executor/runcexecutor/executor.go
@@ -133,7 +133,7 @@ func (w *runcExecutor) Exec(ctx context.Context, meta executor.Meta, root cache.
 	}
 	defer mount.Unmount(rootFSPath, 0)
 
-	uid, gid, err := oci.GetUser(ctx, rootFSPath, meta.User)
+	uid, gid, sgids, err := oci.GetUser(ctx, rootFSPath, meta.User)
 	if err != nil {
 		return err
 	}
@@ -143,7 +143,7 @@ func (w *runcExecutor) Exec(ctx context.Context, meta executor.Meta, root cache.
 		return err
 	}
 	defer f.Close()
-	opts := []containerdoci.SpecOpts{containerdoci.WithUIDGID(uid, gid)}
+	opts := []containerdoci.SpecOpts{oci.WithUIDGID(uid, gid, sgids)}
 	if system.SeccompSupported() {
 		opts = append(opts, seccomp.WithDefaultProfile())
 	}
@@ -170,9 +170,7 @@ func (w *runcExecutor) Exec(ctx context.Context, meta executor.Meta, root cache.
 	}
 
 	if w.rootless {
-		specconv.ToRootless(spec, &specconv.RootlessOpts{
-			MapSubUIDGID: true,
-		})
+		specconv.ToRootless(spec, nil)
 		// TODO(AkihiroSuda): keep Cgroups enabled if /sys/fs/cgroup/cpuset/buildkit exists and writable
 		spec.Linux.CgroupsPath = ""
 		// TODO(AkihiroSuda): ToRootless removes netns, but we should readd netns here

--- a/vendor/github.com/moby/buildkit/frontend/dockerfile/dockerfile2llb/convert_norunmount.go
+++ b/vendor/github.com/moby/buildkit/frontend/dockerfile/dockerfile2llb/convert_norunmount.go
@@ -7,7 +7,7 @@ import (
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 )
 
-func detectRunMount(cmd *command, dispatchStatesByName map[string]*dispatchState, allDispatchStates []*dispatchState) bool {
+func detectRunMount(cmd *command, allDispatchStates *dispatchStates) bool {
 	return false
 }
 

--- a/vendor/github.com/moby/buildkit/frontend/dockerfile/dockerfile2llb/convert_runmount.go
+++ b/vendor/github.com/moby/buildkit/frontend/dockerfile/dockerfile2llb/convert_runmount.go
@@ -5,14 +5,13 @@ package dockerfile2llb
 import (
 	"path"
 	"path/filepath"
-	"strings"
 
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 	"github.com/pkg/errors"
 )
 
-func detectRunMount(cmd *command, dispatchStatesByName map[string]*dispatchState, allDispatchStates []*dispatchState) bool {
+func detectRunMount(cmd *command, allDispatchStates *dispatchStates) bool {
 	if c, ok := cmd.Command.(*instructions.RunCommand); ok {
 		mounts := instructions.GetMounts(c)
 		sources := make([]*dispatchState, len(mounts))
@@ -24,7 +23,7 @@ func detectRunMount(cmd *command, dispatchStatesByName map[string]*dispatchState
 			if from == "" || mount.Type == instructions.MountTypeTmpfs {
 				continue
 			}
-			stn, ok := dispatchStatesByName[strings.ToLower(from)]
+			stn, ok := allDispatchStates.findStateByName(from)
 			if !ok {
 				stn = &dispatchState{
 					stage:        instructions.Stage{BaseName: from},

--- a/vendor/github.com/moby/buildkit/frontend/dockerfile/instructions/bflag.go
+++ b/vendor/github.com/moby/buildkit/frontend/dockerfile/instructions/bflag.go
@@ -72,7 +72,7 @@ func (bf *BFlags) AddString(name string, def string) *Flag {
 	return flag
 }
 
-// AddString adds a string flag to BFlags that can match multiple values
+// AddStrings adds a string flag to BFlags that can match multiple values
 func (bf *BFlags) AddStrings(name string) *Flag {
 	flag := bf.addFlag(name, stringsType)
 	if flag == nil {

--- a/vendor/github.com/moby/buildkit/frontend/dockerfile/instructions/commands.go
+++ b/vendor/github.com/moby/buildkit/frontend/dockerfile/instructions/commands.go
@@ -159,7 +159,7 @@ func (s SourcesAndDest) Dest() string {
 
 // AddCommand : ADD foo /path
 //
-// Add the file 'foo' to '/path'. Tarball and Remote URL (git, http) handling
+// Add the file 'foo' to '/path'. Tarball and Remote URL (http, https) handling
 // exist here. If you do not wish to have this automatic handling, use COPY.
 //
 type AddCommand struct {

--- a/vendor/github.com/moby/buildkit/frontend/dockerfile/shell/equal_env_unix.go
+++ b/vendor/github.com/moby/buildkit/frontend/dockerfile/shell/equal_env_unix.go
@@ -2,8 +2,9 @@
 
 package shell
 
-// EqualEnvKeys compare two strings and returns true if they are equal. On
-// Windows this comparison is case insensitive.
+// EqualEnvKeys compare two strings and returns true if they are equal.
+// On Unix this comparison is case sensitive.
+// On Windows this comparison is case insensitive.
 func EqualEnvKeys(from, to string) bool {
 	return from == to
 }

--- a/vendor/github.com/moby/buildkit/frontend/dockerfile/shell/equal_env_windows.go
+++ b/vendor/github.com/moby/buildkit/frontend/dockerfile/shell/equal_env_windows.go
@@ -2,8 +2,9 @@ package shell
 
 import "strings"
 
-// EqualEnvKeys compare two strings and returns true if they are equal. On
-// Windows this comparison is case insensitive.
+// EqualEnvKeys compare two strings and returns true if they are equal.
+// On Unix this comparison is case sensitive.
+// On Windows this comparison is case insensitive.
 func EqualEnvKeys(from, to string) bool {
 	return strings.ToUpper(from) == strings.ToUpper(to)
 }

--- a/vendor/github.com/moby/buildkit/util/imageutil/config.go
+++ b/vendor/github.com/moby/buildkit/util/imageutil/config.go
@@ -141,13 +141,17 @@ func DetectManifestMediaType(ra content.ReaderAt) (string, error) {
 	}
 
 	var mfst struct {
-		Config json.RawMessage `json:"config"`
+		MediaType string          `json:"mediaType"`
+		Config    json.RawMessage `json:"config"`
 	}
 
 	if err := json.Unmarshal(p, &mfst); err != nil {
 		return "", err
 	}
 
+	if mfst.MediaType != "" {
+		return mfst.MediaType, nil
+	}
 	if mfst.Config != nil {
 		return images.MediaTypeDockerSchema2Manifest, nil
 	}


### PR DESCRIPTION
cherry-pick of https://github.com/moby/moby/pull/37385 for 18.06; cherry-pick was clean, no conflicts

Brings in fixes for:

- https://github.com/moby/buildkit/issues/457 Stripped newlines in non-interactive (`--no-progress`) output
- https://github.com/moby/buildkit/issues/412 dockerfile: USER doesn't set additional group
- https://github.com/moby/buildkit/pull/484 pull: do not send duplicate status for completed jobs
- https://github.com/moby/buildkit/pull/470 Ensure BaseName of Stage is not blank
  - relates to https://github.com/moby/moby/issues/37325


full diff: https://github.com/moby/buildkit/compare/cce2080ddbe4698912f2290892b247c83627efa8...9acf51e49185b348608e0096b2903dd72907adcb