### PR TITLE
[18.06] Add /proc/acpi to masked paths

### DIFF
--- a/oci/defaults.go
+++ b/oci/defaults.go
@@ -114,6 +114,7 @@ func DefaultLinuxSpec() specs.Spec {
 
 	s.Linux = &specs.Linux{
 		MaskedPaths: []string{
+			"/proc/acpi",
 			"/proc/kcore",
 			"/proc/keys",
 			"/proc/latency_stats",


### PR DESCRIPTION
The deafult OCI linux spec in oci/defaults{_linux}.go in Docker/Moby
from 1.11 to current upstream master does not block /proc/acpi pathnames
allowing attackers to modify host's hardware like enabling/disabling
bluetooth or turning up/down keyboard brightness. SELinux prevents all
of this if enabled.

Fix for CVE-2018-10892

cherry-pick of https://github.com/moby/moby/pull/37404 for 18.06 (no conflicts)
