### PR TITLE
[18.06] Fix error string in docker CLI test (Windows RS5)

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -3948,6 +3948,7 @@ func (s *DockerSuite) TestRunAttachFailedNoLeak(c *check.C) {
 	// TODO Windows Post TP5. Fix the error message string
 	c.Assert(strings.Contains(string(out), "port is already allocated") ||
 		strings.Contains(string(out), "were not connected because a duplicate name exists") ||
+		strings.Contains(string(out), "The specified port already exists") ||
 		strings.Contains(string(out), "HNS failed with error : Failed to create endpoint") ||
 		strings.Contains(string(out), "HNS failed with error : The object already exists"), checker.Equals, true, check.Commentf("Output: %s", out))
 	dockerCmd(c, "rm", "-f", "test")


### PR DESCRIPTION
Cherry-pick of https://github.com/moby/moby/pull/37440 for 18.06


```
git checkout -b 18.06-backport-errorfix ce-engine/18.06
git cherry-pick -s -S -x 76ace9bb5e2c5ecdd02046956ab00f76c3b25a3a
git push -u origin
```

cherry-pick was clean; no conflicts