### PR TITLE
[WIP] [18.06] Fix CLI external-ca tests in swarm suite

### DIFF
--- a/integration-cli/docker_cli_swarm_test.go
+++ b/integration-cli/docker_cli_swarm_test.go
@@ -62,9 +62,10 @@ func (s *DockerSwarmSuite) TestSwarmUpdate(c *check.C) {
 	expected, err := ioutil.ReadFile("fixtures/https/ca.pem")
 	c.Assert(err, checker.IsNil)
 
-	spec = getSpec()
+	sw := d.GetSwarm(c)
+	spec = sw.Spec
 	c.Assert(spec.CAConfig.ExternalCAs, checker.HasLen, 2)
-	c.Assert(spec.CAConfig.ExternalCAs[0].CACert, checker.Equals, "")
+	c.Assert(spec.CAConfig.ExternalCAs[0].CACert, checker.Equals, sw.TLSInfo.TrustRoot)
 	c.Assert(spec.CAConfig.ExternalCAs[1].CACert, checker.Equals, string(expected))
 
 	// passing an invalid external CA fails
@@ -108,11 +109,12 @@ func (s *DockerSwarmSuite) TestSwarmInit(c *check.C) {
 	expected, err := ioutil.ReadFile("fixtures/https/ca.pem")
 	c.Assert(err, checker.IsNil)
 
-	spec := getSpec()
+	sw := d.GetSwarm(c)
+	spec := sw.Spec
 	c.Assert(spec.CAConfig.NodeCertExpiry, checker.Equals, 30*time.Hour)
 	c.Assert(spec.Dispatcher.HeartbeatPeriod, checker.Equals, 11*time.Second)
 	c.Assert(spec.CAConfig.ExternalCAs, checker.HasLen, 2)
-	c.Assert(spec.CAConfig.ExternalCAs[0].CACert, checker.Equals, "")
+	c.Assert(spec.CAConfig.ExternalCAs[0].CACert, checker.Equals, sw.TLSInfo.TrustRoot)
 	c.Assert(spec.CAConfig.ExternalCAs[1].CACert, checker.Equals, string(expected))
 
 	c.Assert(d.SwarmLeave(true), checker.IsNil)


### PR DESCRIPTION
https://github.com/docker/cli/pull/1178 changed the CLI behavior so that
the external CA correctly propagates the CA certificate along with the
external CA URL.  Update the tests to reflect that.

Signed-off-by: cyli <cyli@twistedmatrix.com>
(cherry picked from commit c2385171c03b25d7243f097f9f0dacc95ed81d57)

This is a back port of https://github.com/moby/moby/pull/37442

cc @andrewhsu 