### PR TITLE
[18.06] Fix flakyness in TestDockerNetworkInternalMode

### DIFF
--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -1646,9 +1646,9 @@ func (s *DockerSuite) TestDockerNetworkInternalMode(c *check.C) {
 	c.Assert(waitRun("first"), check.IsNil)
 	dockerCmd(c, "run", "-d", "--net=internal", "--name=second", "busybox:glibc", "top")
 	c.Assert(waitRun("second"), check.IsNil)
-	out, _, err := dockerCmdWithError("exec", "first", "ping", "-W", "4", "-c", "1", "www.google.com")
+	out, _, err := dockerCmdWithError("exec", "first", "ping", "-W", "4", "-c", "1", "8.8.8.8")
 	c.Assert(err, check.NotNil)
-	c.Assert(out, checker.Contains, "ping: bad address")
+	c.Assert(out, checker.Contains, "100% packet loss")
 	_, _, err = dockerCmdWithError("exec", "second", "ping", "-c", "1", "first")
 	c.Assert(err, check.IsNil)
 }


### PR DESCRIPTION
cherry-pick of https://github.com/moby/moby/pull/37455 for 18.06


```
git checkout -b 18.06-backport-fix-internal ce-engine/18.06
git cherry-pick -s -S -x a2bb2144b3e0d49ac615976bfac462a307d85f0e
git push -u origin
```

no conflicts, cherry-pick was clean

Instead of waiting for the DNS to fail, try to access
a specific external IP and verify that 100% of the pakcets
are being lost.

