### PR TITLE
[18.06] Return error if basename is expanded to blank

### DIFF
--- a/builder/dockerfile/dispatchers.go
+++ b/builder/dockerfile/dispatchers.go
@@ -274,11 +274,17 @@ func (d *dispatchRequest) getImageOrStage(name string, platform *specs.Platform)
 	}
 	return imageMount.Image(), nil
 }
-func (d *dispatchRequest) getFromImage(shlex *shell.Lex, name string, platform *specs.Platform) (builder.Image, error) {
-	name, err := d.getExpandedString(shlex, name)
+func (d *dispatchRequest) getFromImage(shlex *shell.Lex, basename string, platform *specs.Platform) (builder.Image, error) {
+	name, err := d.getExpandedString(shlex, basename)
 	if err != nil {
 		return nil, err
 	}
+	// Empty string is interpreted to FROM scratch by images.GetImageAndReleasableLayer,
+	// so validate expanded result is not empty.
+	if name == "" {
+		return nil, errors.Errorf("base name (%s) should not be blank", basename)
+	}
+
 	return d.getImageOrStage(name, platform)
 }
 

--- a/builder/dockerfile/dispatchers_test.go
+++ b/builder/dockerfile/dispatchers_test.go
@@ -157,6 +157,22 @@ func TestFromWithArg(t *testing.T) {
 	assert.Check(t, is.Len(sb.state.buildArgs.GetAllMeta(), 1))
 }
 
+func TestFromWithArgButBuildArgsNotGiven(t *testing.T) {
+	b := newBuilderWithMockBackend()
+	args := NewBuildArgs(make(map[string]*string))
+
+	metaArg := instructions.ArgCommand{}
+	cmd := &instructions.Stage{
+		BaseName: "${THETAG}",
+	}
+	err := processMetaArg(metaArg, shell.NewLex('\\'), args)
+
+	sb := newDispatchRequest(b, '\\', nil, args, newStagesBuildResults())
+	assert.NilError(t, err)
+	err = initializeStage(sb, cmd)
+	assert.Error(t, err, "base name (${THETAG}) should not be blank")
+}
+
 func TestFromWithUndefinedArg(t *testing.T) {
 	tag, expected := "sometag", "expectedthisid"
 


### PR DESCRIPTION
cherry-pick of https://github.com/moby/moby/pull/37396 for 18.06

```
git checkout -b 18.06-backport-error_when_base_name_resolved_to_blank ce-engine/18.06
git cherry-pick -s -S -x c9542d313e2a52807644742e5fd684bc2de9f507
```

cherry-pick was clean; no conflicts


Fix: https://github.com/moby/moby/issues/37325

