### PR TITLE
[17.03] Patch go connections

### DIFF
--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -234,8 +234,9 @@ func newHTTPClient(host string, tlsOptions *tlsconfig.Options) (*http.Client, er
 		// let the api client configure the default transport.
 		return nil, nil
 	}
-
-	config, err := tlsconfig.Client(*tlsOptions)
+	opts := *tlsOptions
+	opts.ExclusiveRootPools = true
+	config, err := tlsconfig.Client(opts)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -186,9 +186,10 @@ func (cli *DaemonCli) start(opts daemonOptions) (err error) {
 
 	if cli.Config.TLS {
 		tlsOptions := tlsconfig.Options{
-			CAFile:   cli.Config.CommonTLSOptions.CAFile,
-			CertFile: cli.Config.CommonTLSOptions.CertFile,
-			KeyFile:  cli.Config.CommonTLSOptions.KeyFile,
+			CAFile:             cli.Config.CommonTLSOptions.CAFile,
+			CertFile:           cli.Config.CommonTLSOptions.CertFile,
+			KeyFile:            cli.Config.CommonTLSOptions.KeyFile,
+			ExclusiveRootPools: true,
 		}
 
 		if cli.Config.TLSVerify {

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -23,6 +23,8 @@ import (
 
 	"github.com/docker/docker/pkg/integration/checker"
 	icmd "github.com/docker/docker/pkg/integration/cmd"
+
+	"github.com/docker/docker/integration-cli/checker"
 	"github.com/docker/docker/pkg/mount"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/go-units"
@@ -1822,8 +1824,8 @@ func (s *DockerDaemonSuite) TestDaemonStartWithoutHost(c *check.C) {
 	c.Assert(s.d.Start(), check.IsNil)
 }
 
-func (s *DockerDaemonSuite) TestDaemonStartWithDefalutTLSHost(c *check.C) {
-	s.d.useDefaultTLSHost = true
+func (s *DockerDaemonSuite) TestDaemonStartWithDefaultTLSHost(c *check.C) {
+	s.d.UseDefaultTLSHost = true
 	defer func() {
 		s.d.useDefaultTLSHost = false
 	}()
@@ -1854,6 +1856,33 @@ func (s *DockerDaemonSuite) TestDaemonStartWithDefalutTLSHost(c *check.C) {
 	if !strings.Contains(out, "Server") {
 		c.Fatalf("docker version should return information of server side")
 	}
+
+	// // ensure when connecting to the server that only a single acceptable CA is requested
+	// contents, err := ioutil.ReadFile("fixtures/https/ca.pem")
+	// c.Assert(err, checker.IsNil)
+	// rootCert, err := helpers.ParseCertificatePEM(contents)
+	// c.Assert(err, checker.IsNil)
+	// rootPool := x509.NewCertPool()
+	// rootPool.AddCert(rootCert)
+
+	// var certRequestInfo *tls.CertificateRequestInfo
+	// conn, err := tls.Dial("tcp", fmt.Sprintf("%s:%d", opts.DefaultHTTPHost, opts.DefaultTLSHTTPPort), &tls.Config{
+	// 	RootCAs: rootPool,
+	// 	GetClientCertificate: func(cri *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+	// 		certRequestInfo = cri
+	// 		cert, err := tls.LoadX509KeyPair("fixtures/https/client-cert.pem", "fixtures/https/client-key.pem")
+	// 		if err != nil {
+	// 			return nil, err
+	// 		}
+	// 		return &cert, nil
+	// 	},
+	// })
+	// c.Assert(err, checker.IsNil)
+	// conn.Close()
+
+	// c.Assert(certRequestInfo, checker.NotNil)
+	// c.Assert(certRequestInfo.AcceptableCAs, checker.HasLen, 1)
+	// c.Assert(certRequestInfo.AcceptableCAs[0], checker.DeepEquals, rootCert.RawSubject)
 }
 
 func (s *DockerDaemonSuite) TestBridgeIPIsExcludedFromAllocatorPool(c *check.C) {

--- a/vendor.conf
+++ b/vendor.conf
@@ -17,7 +17,7 @@ github.com/vdemeester/shakers 24d7f1d6a71aa5d9cbe7390e4afb66b7eef9e1b3
 golang.org/x/net 2beffdc2e92c8a3027590f898fe88f69af48a3f8 https://github.com/tonistiigi/net.git
 golang.org/x/sys 8f0908ab3b2457e2e15403d3697c9ef5cb4b57a9
 github.com/docker/go-units 8a7beacffa3009a9ac66bad506b18ffdd110cf97
-github.com/docker/go-connections ecb4cb2dd420ada7df7f2593d6c25441f65f69f2
+github.com/docker/go-connections d217f8e36aba4dbc397981e692a65d3f13b9a46d
 
 github.com/RackSec/srslog 456df3a81436d29ba874f3590eeeee25d666f8a5
 github.com/imdario/mergo 0.2.1

--- a/vendor/github.com/docker/go-connections/tlsconfig/config.go
+++ b/vendor/github.com/docker/go-connections/tlsconfig/config.go
@@ -29,6 +29,11 @@ type Options struct {
 	InsecureSkipVerify bool
 	// server-only option
 	ClientAuth tls.ClientAuthType
+
+	// If ExclusiveRootPools is set, then if a CA file is provided, the root pool used for TLS
+	// creds will include exclusively the roots in that CA file.  If no CA file is provided,
+	// the system pool will be used.
+	ExclusiveRootPools bool
 }
 
 // Extra (server-side) accepted CBC cipher suites - will phase out in the future
@@ -66,11 +71,19 @@ func ClientDefault() *tls.Config {
 }
 
 // certPool returns an X.509 certificate pool from `caFile`, the certificate file.
-func certPool(caFile string) (*x509.CertPool, error) {
+func certPool(caFile string, exclusivePool bool) (*x509.CertPool, error) {
 	// If we should verify the server, we need to load a trusted ca
-	certPool, err := SystemCertPool()
-	if err != nil {
-		return nil, fmt.Errorf("failed to read system certificates: %v", err)
+	var (
+		certPool *x509.CertPool
+		err      error
+	)
+	if exclusivePool {
+		certPool = x509.NewCertPool()
+	} else {
+		certPool, err = SystemCertPool()
+		if err != nil {
+			return nil, fmt.Errorf("failed to read system certificates: %v", err)
+		}
 	}
 	pem, err := ioutil.ReadFile(caFile)
 	if err != nil {
@@ -88,7 +101,7 @@ func Client(options Options) (*tls.Config, error) {
 	tlsConfig := ClientDefault()
 	tlsConfig.InsecureSkipVerify = options.InsecureSkipVerify
 	if !options.InsecureSkipVerify && options.CAFile != "" {
-		CAs, err := certPool(options.CAFile)
+		CAs, err := certPool(options.CAFile, options.ExclusiveRootPools)
 		if err != nil {
 			return nil, err
 		}
@@ -119,7 +132,7 @@ func Server(options Options) (*tls.Config, error) {
 	}
 	tlsConfig.Certificates = []tls.Certificate{tlsCert}
 	if options.ClientAuth >= tls.VerifyClientCertIfGiven && options.CAFile != "" {
-		CAs, err := certPool(options.CAFile)
+		CAs, err := certPool(options.CAFile, options.ExclusiveRootPools)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This is a cherry pick of the following 2 PRs:

- https://github.com/moby/moby/pull/33182
- https://github.com/moby/moby/pull/31977 (picked from the 17.04 one because the diff was smaller)

Cherry picks were not clean, but was a pretty easy resolution.

Unfortunately the test can't be merged - the test depends on features in go 1.8.x (`GetClientCertificate`), and 17.03 was on go 1.7.5.

Either I will have to try to figure out how to write a new test, or we leave it out.