### PR TITLE
[18.06] disable containerd CRI plugin

### DIFF
--- a/libcontainerd/remote_daemon_linux.go
+++ b/libcontainerd/remote_daemon_linux.go
@@ -37,6 +37,10 @@ func (r *remote) setDefaults() {
 	if r.snapshotter == "" {
 		r.snapshotter = "overlay"
 	}
+	// Disable CRI plugin by default if containerd is managed as child-process
+	// of dockerd. See https://github.com/moby/moby/issues/37507
+	r.DisabledPlugins = append(r.DisabledPlugins, "cri")
+	delete(r.pluginConfs.Plugins, "cri")
 }
 
 func (r *remote) stopDaemon() {


### PR DESCRIPTION
Implementation of https://github.com/moby/moby/pull/37519 fr 18.06, but without configuration option.

fixes https://github.com/moby/moby/issues/37507 for 18.06


Docker 18.06 does not have a configuration option to disable the CRI plugin, and this plugin is not very useful if containerd is not running standalone.

This patch disables the plugin if containerd is running as child-process of dockerd.


**- How to verify it**

- build dockerd with this patch
- start the daemon (`dockerd &`)
- verify that the plugin is disabled in containerd's generated configuration file;

```
cat /var/run/docker/containerd/containerd.toml | grep disabled_plugins
disabled_plugins = ["cri"]
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```
* Disable the containerd CRI plugin if containerd is running as child-process of dockerd
```
