### PR TITLE
[18.06] Bump SwarmKit to 8852e88

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -125,7 +125,7 @@ github.com/containerd/ttrpc 94dde388801693c54f88a6596f713b51a8b30b2d
 github.com/gogo/googleapis 08a7655d27152912db7aaf4f983275eaf8d128ef
 
 # cluster
-github.com/docker/swarmkit 68266392a176434d282760d2d6d0ab4c68edcae6
+github.com/docker/swarmkit 8852e8840e30d69db0b39a4a3d6447362e17c64f
 github.com/gogo/protobuf v1.0.0
 github.com/cloudflare/cfssl 7fb22c8cba7ecaf98e4082d22d65800cf45e042a
 github.com/fernet/fernet-go 1b2437bc582b3cfbb341ee5a29f8ef5b42912ff2

--- a/vendor/github.com/docker/swarmkit/agent/agent.go
+++ b/vendor/github.com/docker/swarmkit/agent/agent.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"bytes"
-	"fmt"
 	"math/rand"
 	"reflect"
 	"sync"
@@ -11,6 +10,7 @@ import (
 	"github.com/docker/swarmkit/agent/exec"
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/log"
+	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
 
@@ -444,7 +444,7 @@ func (a *Agent) handleSessionMessage(ctx context.Context, message *api.SessionMe
 		if !same {
 			a.keys = message.NetworkBootstrapKeys
 			if err := a.config.Executor.SetNetworkBootstrapKeys(a.keys); err != nil {
-				panic(fmt.Errorf("configuring network key failed"))
+				return errors.Wrap(err, "configuring network key failed")
 			}
 		}
 	}

--- a/vendor/github.com/docker/swarmkit/agent/session.go
+++ b/vendor/github.com/docker/swarmkit/agent/session.go
@@ -12,6 +12,7 @@ import (
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 var (
@@ -195,7 +196,8 @@ func (s *session) heartbeat(ctx context.Context) error {
 			cancel()
 			if err != nil {
 				log.G(ctx).WithFields(fields).WithError(err).Errorf("heartbeat to manager %v failed", s.conn.Peer())
-				if grpc.Code(err) == codes.NotFound {
+				st, _ := status.FromError(err)
+				if st.Code() == codes.NotFound {
 					err = errNodeNotRegistered
 				}
 
@@ -252,7 +254,8 @@ func (s *session) logSubscriptions(ctx context.Context) error {
 
 	for {
 		resp, err := subscriptions.Recv()
-		if grpc.Code(err) == codes.Unimplemented {
+		st, _ := status.FromError(err)
+		if st.Code() == codes.Unimplemented {
 			log.Warning("manager does not support log subscriptions")
 			// Don't return, because returning would bounce the session
 			select {
@@ -303,7 +306,8 @@ func (s *session) watch(ctx context.Context) error {
 			// If we get a code = 12 desc = unknown method Assignments, try to use tasks
 			resp, err = assignmentWatch.Recv()
 			if err != nil {
-				if grpc.Code(err) != codes.Unimplemented {
+				st, _ := status.FromError(err)
+				if st.Code() != codes.Unimplemented {
 					return err
 				}
 				tasksFallback = true
@@ -362,20 +366,21 @@ func (s *session) watch(ctx context.Context) error {
 }
 
 // sendTaskStatus uses the current session to send the status of a single task.
-func (s *session) sendTaskStatus(ctx context.Context, taskID string, status *api.TaskStatus) error {
+func (s *session) sendTaskStatus(ctx context.Context, taskID string, taskStatus *api.TaskStatus) error {
 	client := api.NewDispatcherClient(s.conn.ClientConn)
 	if _, err := client.UpdateTaskStatus(ctx, &api.UpdateTaskStatusRequest{
 		SessionID: s.sessionID,
 		Updates: []*api.UpdateTaskStatusRequest_TaskStatusUpdate{
 			{
 				TaskID: taskID,
-				Status: status,
+				Status: taskStatus,
 			},
 		},
 	}); err != nil {
 		// TODO(stevvooe): Dispatcher should not return this error. Status
 		// reports for unknown tasks should be ignored.
-		if grpc.Code(err) == codes.NotFound {
+		st, _ := status.FromError(err)
+		if st.Code() == codes.NotFound {
 			return errTaskUnknown
 		}
 

--- a/vendor/github.com/docker/swarmkit/manager/manager.go
+++ b/vendor/github.com/docker/swarmkit/manager/manager.go
@@ -962,7 +962,7 @@ func (m *Manager) becomeLeader(ctx context.Context) {
 		// in order to allow running services on the predefined docker
 		// networks like `bridge` and `host`.
 		for _, p := range allocator.PredefinedNetworks() {
-			if err := store.CreateNetwork(tx, newPredefinedNetwork(p.Name, p.Driver)); err != store.ErrNameConflict {
+			if err := store.CreateNetwork(tx, newPredefinedNetwork(p.Name, p.Driver)); err != nil && err != store.ErrNameConflict {
 				log.G(ctx).WithError(err).Error("failed to create predefined network " + p.Name)
 			}
 		}

--- a/vendor/github.com/docker/swarmkit/vendor.conf
+++ b/vendor/github.com/docker/swarmkit/vendor.conf
@@ -12,7 +12,7 @@ google.golang.org/grpc v1.12.0
 github.com/gogo/protobuf v1.0.0
 github.com/golang/protobuf v1.1.0
 github.com/matttproud/golang_protobuf_extensions v1.0.0
-google.golang.org/genproto d80a6e20e776b0b17a324d0ba1ab50a39c8e8944
+google.golang.org/genproto 694d95ba50e67b2e363f3483057db5d4910c18f9
 
 # metrics
 github.com/grpc-ecosystem/go-grpc-prometheus 6b7015e65d366bf3f19b2b2a000a831940f0f7e0
@@ -20,35 +20,35 @@ github.com/docker/go-metrics d466d4f6fd960e01820085bd7e1a24426ee7ef18
 
 # etcd/raft
 github.com/coreos/etcd v3.2.1
-github.com/coreos/go-systemd v15
+github.com/coreos/go-systemd v17
 github.com/coreos/pkg v3
 github.com/prometheus/client_golang 52437c81da6b127a9925d17eb3a382a2e5fd395e
 github.com/prometheus/client_model fa8ad6fec33561be4280a8f0514318c79d7f6cb6
 github.com/prometheus/common ebdfc6da46522d58825777cf1f90490a5b1ef1d8
 github.com/prometheus/procfs abf152e5f3e97f2fafac028d2cc06c1feb87ffa5
 
-github.com/docker/distribution edc3ab29cdff8694dd6feb85cfeb4b5f1b38ed9c
-github.com/docker/docker 3d14173a2900b60200d9b1475abd5138f4315981
+github.com/docker/distribution 83389a148052d74ac602f5f1d62f86ff2f3c4aa5
+github.com/docker/docker b9bb3bae5161f931c1dede43c67948c599197f50
 github.com/docker/go-connections 7beb39f0b969b075d1325fecb092faf27fd357b6
 github.com/docker/go-events 9461782956ad83b30282bf90e31fa6a70c255ba9
 github.com/docker/go-units 9e638d38cf6977a37a8ea0078f3ee75a7cdb2dd1
 github.com/docker/libkv 1d8431073ae03cdaedb198a89722f3aab6d418ef
-github.com/docker/libnetwork 1b91bc94094ecfdae41daa465cc0c8df37dfb3dd
-github.com/opencontainers/runc 4fc53a81fb7c994640722ac585fa9ca548971871
-github.com/opencontainers/go-digest 21dfd564fd89c944783d00d069f33e3e7123c448
+github.com/docker/libnetwork d00ceed44cc447c77f25cdf5d59e83163bdcb4c9
+github.com/opencontainers/runc ad0f5255060d36872be04de22f8731f38ef2d7b1
+github.com/opencontainers/go-digest v1.0.0-rc1
 github.com/opencontainers/image-spec v1.0.1
 github.com/ishidawataru/sctp 07191f837fedd2f13d1ec7b5f885f0f3ec54b1cb
 
 github.com/davecgh/go-spew 346938d642f2ec3594ed81d874461961cd0faa76 # v1.1.0
-github.com/Microsoft/go-winio v0.4.6
+github.com/Microsoft/go-winio v0.4.8
 github.com/sirupsen/logrus v1.0.3
 github.com/beorn7/perks 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
 github.com/boltdb/bolt fff57c100f4dea1905678da7e90d92429dff2904
 github.com/cloudflare/cfssl 1.3.2
 github.com/dustin/go-humanize 8929fe90cee4b2cb9deb468b51fb34eba64d1bf0
 github.com/fernet/fernet-go 1b2437bc582b3cfbb341ee5a29f8ef5b42912ff2
-github.com/google/certificate-transparency-go 5ab67e519c93568ac3ee50fd6772a5bcf8aa460d
-github.com/hashicorp/go-immutable-radix 8e8ed81f8f0bf1bdd829593fdd5c29922c1ea990
+github.com/google/certificate-transparency-go v1.0.20
+github.com/hashicorp/go-immutable-radix 826af9ccf0feeee615d546d69b11f8e98da8c8f1 git://github.com/tonistiigi/go-immutable-radix.git
 github.com/hashicorp/go-memdb cb9a474f84cc5e41b273b20c6927680b2a8776ad
 github.com/hashicorp/golang-lru a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4
 github.com/inconshreveable/mousetrap 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
@@ -60,8 +60,8 @@ github.com/rcrowley/go-metrics 51425a2415d21afadfd55cd93432c0bc69e9598d
 github.com/spf13/cobra 8e91712f174ced10270cf66615e0a9127e7c4de5
 github.com/spf13/pflag 7f60f83a2c81bc3c3c0d5297f61ddfa68da9d3b7
 github.com/stretchr/testify v1.1.4
-golang.org/x/crypto 650f4a345ab4e5b245a3034b110ebc7299e68186
-golang.org/x/net 7dcfb8076726a3fdd9353b6b8a1f1b6be6811bd6
+golang.org/x/crypto 1a580b3eff7814fc9b40602fd35256c63b50f491
+golang.org/x/net 0ed95abb35c445290478a5348a7b38bb154135fd
 golang.org/x/sys 37707fdb30a5b38865cfb95e5aab41707daec7fd
 golang.org/x/text f72d8390a633d5dfb0cc84043294db9f6c935756
 golang.org/x/time a4bde12657593d5e90d0533a3e4fd95e635124cb


### PR DESCRIPTION
Backport of https://github.com/moby/moby/pull/37586 for 18.06

```
git checkout -b 18.06-bump_swarmkit ce-engine/18.06
git cherry-pick -s -S -x 660fa129c0ea09c1aa1770b5f2d26ec762213484
git push -u origin
```

cherry-pick was clean; no conflicts


Full diff: https://github.com/docker/swarmkit/compare/68266392a176434d282760d2d6d0ab4c68edcae6...8852e8840e30d69db0b39a4a3d6447362e17c64f

Relevant changes;

- https://github.com/docker/swarmkit/pull/2593 agent: return error when failing to apply network key 
- https://github.com/docker/swarmkit/pull/2645 Replace deprecated grpc functions
- https://github.com/docker/swarmkit/pull/2720 Test if error is nil before to log it
- https://github.com/docker/swarmkit/pull/2712 [orchestrator] Fix task sorting
  - addresses https://github.com/docker/swarmkit/issues/2705
- https://github.com/docker/swarmkit/pull/2677 [manager/orchestrator/reaper] Fix the condition used for skipping over running tasks
  - Addresses the following from https://github.com/docker/swarmkit/issues/2672#issuecomment-399598738
