### PR TITLE
[18.06] backport "fix relabeling local volume source dir"

### DIFF
--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -210,6 +210,8 @@ func (daemon *Daemon) registerMountPoints(container *container.Container, hostCo
 			mp.Name = v.Name
 			mp.Driver = v.Driver
 
+			// need to selinux-relabel local mounts
+			mp.Source = v.Mountpoint
 			if mp.Driver == volume.DefaultDriverName {
 				setBindModeIfNull(mp)
 			}


### PR DESCRIPTION
Backport of https://github.com/moby/moby/pull/37739.

```
git checkout -b 18.06-backport-pr37739 engine/18.06
git cherry-pick 27d9030b2371aa4a6b167fded6b8dc25987a0af7
git push kir 18.06-backport-pr37739
```

Clean cherry-pick, no issues.