### PR TITLE
[18.09] backport "fix relabeling local volume source dir"

### DIFF
--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -210,6 +210,8 @@ func (daemon *Daemon) registerMountPoints(container *container.Container, hostCo
 			mp.Name = v.Name
 			mp.Driver = v.Driver
 
+			// need to selinux-relabel local mounts
+			mp.Source = v.Mountpoint
 			if mp.Driver == volume.DefaultDriverName {
 				setBindModeIfNull(mp)
 			}


### PR DESCRIPTION
Backport of https://github.com/moby/moby/pull/37739.

```
git checkout -b 18.09-backport-pr37739 18.09
git cherry-pick 27d9030b2371aa4a6b167fded6b8dc25987a0af7
git push -f kir
```

Cherry-pick was clean, no issues.

------
In case a volume is specified via Mounts API, and SELinux is enabled,
the following error happens on container start:

> $ docker volume create testvol
> $ docker run --rm --mount source=testvol,target=/tmp busybox true
> docker: Error response from daemon: error setting label on mount
> source '': no such file or directory.

The functionality to relabel the source of a local mount specified via
Mounts API was introduced in commit 5bbf5cc and later broken by commit
e4b6adc, which removed setting mp.Source field.

With the current data structures, the host dir is already available in
v.Mountpoint, so let's just use it.