### PR TITLE
[18.09] client: dial tls on Dialer if tls config is set

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -413,7 +413,7 @@ func (cli *Client) SetCustomHTTPHeaders(headers map[string]string) {
 func (cli *Client) Dialer() func(context.Context) (net.Conn, error) {
 	return func(ctx context.Context) (net.Conn, error) {
 		if transport, ok := cli.client.Transport.(*http.Transport); ok {
-			if transport.DialContext != nil {
+			if transport.DialContext != nil && transport.TLSClientConfig == nil {
 				return transport.DialContext(ctx, cli.proto, cli.addr)
 			}
 		}


### PR DESCRIPTION
backport:
* https://github.com/moby/moby/pull/37761 client: dial tls on Dialer if tls config is set

cherry pick https://github.com/moby/moby/pull/37761/commits/5974fc2 has no conflicts
```
$ git cherry-pick -s -x 5974fc2
[tls c2d0053207] client: dial tls on Dialer if tls config is set
 Author: Tonis Tiigi <tonistiigi@gmail.com>
 Date: Tue Sep 4 15:09:44 2018 -0700
 1 file changed, 1 insertion(+), 1 deletion(-)
```