### PR TITLE
[18.09] backport always hornor client side to choose which builder to use with DOCKER_…

### DIFF
--- a/api/server/router/build/build_routes.go
+++ b/api/server/router/build/build_routes.go
@@ -250,12 +250,6 @@ func (br *buildRouter) postBuild(ctx context.Context, w http.ResponseWriter, r *
 		return errdefs.InvalidParameter(errors.New("squash is only supported with experimental mode"))
 	}
 
-	builderVersion := BuilderVersion(*br.features)
-	// check if the builder feature has been enabled from daemon as well.
-	if buildOptions.Version == types.BuilderBuildKit && builderVersion != "" && builderVersion != types.BuilderBuildKit {
-		return errdefs.InvalidParameter(errors.New("buildkit is not enabled on daemon"))
-	}
-
 	out := io.Writer(output)
 	if buildOptions.SuppressOutput {
 		out = notVerboseBuffer


### PR DESCRIPTION
…BUILDKIT env var regardless the server setup


backport of https://github.com/moby/moby/pull/37826 for 18.09

```
git checkout -b 18.09_backport_buildkit-cli-control ce-engine/18.09
git cherry-pick -s -S -x 5d931705e33927ba9f0b7251b74b6b3c450edaf6  
```

cherry-pick was clean; no conflicts
