### PR TITLE
[18.09] backport pkg/progress: work around closing closed channel panic

### DIFF
--- a/pkg/progress/progress.go
+++ b/pkg/progress/progress.go
@@ -39,6 +39,10 @@ type Output interface {
 type chanOutput chan<- Progress
 
 func (out chanOutput) WriteProgress(p Progress) error {
+	// FIXME: workaround for panic in #37735
+	defer func() {
+		recover()
+	}()
 	out <- p
 	return nil
 }


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/37780 for 18.09

```
git checkout -b 18.09_backport_fix-progress-panic ce-engine/18.09  
git cherry-pick -s -S -x 7dac70324d0ce6acd23458b0bef06f099837d648
```

cherry-pick was clean; no conflicts


I could not reproduce the panic in https://github.com/moby/moby/issues/37735, so here's a bandaid.

