### PR TITLE
[18.09] backport update containerd to v1.1.4

### DIFF
--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-CONTAINERD_COMMIT=468a545b9edcd5932818eb9de8e72413e616e86e # v1.1.2
+CONTAINERD_COMMIT=9f2e07b1fc1342d1c48fe4d7bbb94cb6d1bf278b # v1.1.4
 
 install_containerd() {
 	echo "Install containerd version $CONTAINERD_COMMIT"


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/37925 for 18.09


```
git checkout -b 18.09_backport_bump_containerd_1.1.4 ce-engine/18.09
git cherry-pick -s -S -x b3c3c7a5a310ba340f1a86a4a708de34b9602e74
git push -u origin
```

cherry-pick was clean


Fixes a potential content store bug, backported from 1.2

- v1.1.3 release notes: https://github.com/containerd/containerd/releases/tag/v1.1.3
- v1.1.4 release notes: https://github.com/containerd/containerd/releases/tag/v1.1.4

Full diff: https://github.com/containerd/containerd/compare/v1.1.2...v1.1.4

changes;

- https://github.com/containerd/containerd/pull/2473 [release/1.1] Fix options ordering in proto api txt files
- https://github.com/containerd/containerd/pull/2488 [release/1.1] native: set '/' permission to 0755
- https://github.com/containerd/containerd/pull/2472 [release/1.1] Move ContainerFlags to "commands" package
- https://github.com/containerd/containerd/pull/2539 Update cri plugin to v1.0.5
- https://github.com/containerd/containerd/pull/2556 [release/1.1] Cherrypick "Set gid 0 when no group is specified" and docs update
- https://github.com/containerd/containerd/pull/2600 [release/1.1] Cherrypick: Support >= 128 layers in overlayfs snapshots
- https://github.com/containerd/containerd/pull/2637 [release/1.1] Backport: With-helper for supplemental gid support
- https://github.com/containerd/containerd/pull/2645 [release/1.1] Backport: Support uid in WithAdditionalGIDs
- https://github.com/containerd/containerd/pull/2657 [release/1.1] Update cri to f117382467baf182382c44332bfbf488effc34bb.
- https://github.com/containerd/containerd/pull/2654 [release/1.1] Backported: check exists on content commit + testcase
- https://github.com/containerd/containerd/pull/2668 [release/1.1] Backport: Add flag to ctr for running with NoNewPrivileges: false
- https://github.com/containerd/containerd/pull/2677 [release/1.1] Update continuity

