### PR TITLE
[18.09] backport: gd/dm: fix error message

### DIFF
--- a/daemon/graphdriver/devmapper/device_setup.go
+++ b/daemon/graphdriver/devmapper/device_setup.go
@@ -27,7 +27,7 @@ type directLVMConfig struct {
 var (
 	errThinpPercentMissing = errors.New("must set both `dm.thinp_percent` and `dm.thinp_metapercent` if either is specified")
 	errThinpPercentTooBig  = errors.New("combined `dm.thinp_percent` and `dm.thinp_metapercent` must not be greater than 100")
-	errMissingSetupDevice  = errors.New("must provide device path in `dm.setup_device` in order to configure direct-lvm")
+	errMissingSetupDevice  = errors.New("must provide device path in `dm.directlvm_device` in order to configure direct-lvm")
 )
 
 func validateLVMConfig(cfg directLVMConfig) error {


### PR DESCRIPTION
Backport of https://github.com/moby/moby/pull/37951 for 18.09


```
git checkout -b 18.09_backport_fix-dm-errmsg ce-engine/18.09
git cherry-pick -s -S -x c378fb774e413ba8bf5cadf655d2b67e9c94245a
git push -u origin
```

cherry-pick was clean; no conflicts

The parameter name was wrong, which may mislead a user.

