### PR TITLE
[18.09] Fix long startup on windows, with non-hns governed Hyper-V networks

### DIFF
--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -323,7 +323,8 @@ func (daemon *Daemon) initNetworkController(config *config.Config, activeSandbox
 	// discover and add HNS networks to windows
 	// network that exist are removed and added again
 	for _, v := range hnsresponse {
-		if strings.ToLower(v.Type) == "private" {
+		networkTypeNorm := strings.ToLower(v.Type)
+		if networkTypeNorm == "private" || networkTypeNorm == "internal" {
 			continue // workaround for HNS reporting unsupported networks
 		}
 		var n libnetwork.Network


### PR DESCRIPTION
Backport of https://github.com/moby/moby/pull/37774 for 18.09


```
git checkout -b 18.09_backport_windows-network-plugin-miss-fix ce-engine/18.09
git cherry-pick -s -S -x 6a1a4f97217b0a8635bc21fc86628f48bf8824d1
git push -u origin
```

cherry-pick was clean; no conflicts


Similar to a related issue where previously, private Hyper-V networks
would each add 15 secs to the daemon startup, non-hns governed internal
networks are reported by hns as network type "internal" which is not
mapped to any network plugin (and thus we get the same plugin load retry
loop as before).

This issue hits Docker for Desktop because we setup such a network for
the Linux VM communication.

