### PR TITLE
[18.09] backport default-addr-pool-mask-length param max value check

### DIFF
--- a/daemon/cluster/listen_addr.go
+++ b/daemon/cluster/listen_addr.go
@@ -99,7 +99,12 @@ func validateDefaultAddrPool(defaultAddrPool []string, size uint32) error {
 	if size == 0 {
 		size = 24
 	}
-	if size > 32 {
+	// We allow max value as 29. We can have 8 IP addresses for max value 29
+	// If we allow 30, then we will get only 4 IP addresses. But with latest
+	// libnetwork LB scale implementation, we use total of 4 IP addresses for internal use.
+	// Hence keeping 29 as max value, we will have 8 IP addresses. This will be
+	// smallest subnet that can be used in overlay network.
+	if size > 29 {
 		return fmt.Errorf("subnet size is out of range: %d", size)
 	}
 	for i := range defaultAddrPool {

--- a/daemon/cluster/swarm.go
+++ b/daemon/cluster/swarm.go
@@ -92,6 +92,10 @@ func (c *Cluster) Init(req types.InitRequest) (string, error) {
 		}
 	}
 
+	//Validate Default Address Pool input
+	if err := validateDefaultAddrPool(req.DefaultAddrPool, req.SubnetSize); err != nil {
+		return "", err
+	}
 	nr, err := c.newNodeRunner(nodeStartConfig{
 		forceNewCluster:    req.ForceNewCluster,
 		autolock:           req.AutoLockManagers,

--- a/integration/network/service_test.go
+++ b/integration/network/service_test.go
@@ -355,7 +355,7 @@ func TestServiceWithDefaultAddressPoolInit(t *testing.T) {
 	d.Stop(t)
 
 	// Clean up , set it back to original one to make sure other tests don't fail
-	ipAddr = []string{"10.10.0.0/8"}
+	ipAddr = []string{"10.0.0.0/8"}
 	ops = append(ops, daemon.WithSwarmDefaultAddrPool(ipAddr))
 	ops = append(ops, daemon.WithSwarmDefaultAddrPoolSubnetSize(24))
 	d = swarm.NewSwarm(t, testEnv, ops...)


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/37736 and https://github.com/moby/moby/pull/37949 for 18.09

```
git checkout -b 18.09_backport_addr_pool ce-engine/18.09
git cherry-pick -s -S -x 148ff00a0a800fad99de11ee3021d4c5d4869157
git cherry-pick -s -S -x d25c5df80e60cdbdc23fe3d0e2a6808123643dc7
```

conflict in daemon/cluster/noderunner.go and vendor.conf, due to https://github.com/docker/engine/pull/60, which is not in upstream

```patch
diff --cc daemon/cluster/noderunner.go
index 071d8af5a7,aa905d6780..0000000000
--- a/daemon/cluster/noderunner.go
+++ b/daemon/cluster/noderunner.go
@@@ -13,7 -13,7 +13,11 @@@ import 
        "github.com/docker/docker/daemon/cluster/executor/container"
        lncluster "github.com/docker/libnetwork/cluster"
        swarmapi "github.com/docker/swarmkit/api"
++<<<<<<< HEAD
 +      "github.com/docker/swarmkit/manager/allocator/cnmallocator"
++=======
+       swarmallocator "github.com/docker/swarmkit/manager/allocator/cnmallocator"
++>>>>>>> 148ff00a0a... Global Default AddressPool - Update
        swarmnode "github.com/docker/swarmkit/node"
        "github.com/pkg/errors"
        "github.com/sirupsen/logrus"
@@@ -122,7 -122,7 +126,11 @@@ func (n *nodeRunner) start(conf nodeSta
                ListenControlAPI:   control,
                ListenRemoteAPI:    conf.ListenAddr,
                AdvertiseRemoteAPI: conf.AdvertiseAddr,
++<<<<<<< HEAD
 +              NetworkConfig: &cnmallocator.NetworkConfig{
++=======
+               NetworkConfig: &swarmallocator.NetworkConfig{
++>>>>>>> 148ff00a0a... Global Default AddressPool - Update
                        DefaultAddrPool: conf.DefaultAddressPool,
                        SubnetSize:      conf.SubnetSize,
                },
diff --cc vendor.conf
index d6a41a3759,6070edbac6..0000000000
--- a/vendor.conf
+++ b/vendor.conf
```