### PR TITLE
Switch copy image to a docker org based one

### DIFF
--- a/builder/builder-next/builder.go
+++ b/builder/builder-next/builder.go
@@ -221,7 +221,9 @@ func (b *Builder) Build(ctx context.Context, opt backend.BuildConfig) (*builder.
 
 	id := identity.NewID()
 
-	frontendAttrs := map[string]string{}
+	frontendAttrs := map[string]string{
+		"override-copy-image": "docker.io/docker/dockerfile-copy:v0.1.7@sha256:4211460d4df58cca572825b93e437c09dac6387d88910fe07ac8f7c78d52e0ce",
+	}
 
 	if opt.Options.Target != "" {
 		frontendAttrs["target"] = opt.Options.Target


### PR DESCRIPTION
Backport of https://github.com/moby/moby/pull/37980

Switches copy image to be one based in the `docker` docker hub organization.

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>
(cherry picked from commit 5cfd110c306d6a370307178b84d2b98d8598acc4)
Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>