### PR TITLE
[18.06] backport bugfix: wait for stdin creation before CloseIO

### DIFF
--- a/integration/container/exec_test.go
+++ b/integration/container/exec_test.go
@@ -18,7 +18,7 @@ import (
 
 // TestExecWithCloseStdin adds case for moby#37870 issue.
 func TestExecWithCloseStdin(t *testing.T) {
-	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.39"), "broken in earlier versions")
+	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.38"), "broken in earlier versions")
 	defer setupTest(t)()
 
 	ctx := context.Background()

--- a/libcontainerd/client_daemon.go
+++ b/libcontainerd/client_daemon.go
@@ -332,6 +332,13 @@ func (c *client) Start(ctx context.Context, id, checkpointDir string, withStdin 
 	return int(t.Pid()), nil
 }
 
+// Exec creates exec process.
+//
+// The containerd client calls Exec to register the exec config in the shim side.
+// When the client calls Start, the shim will create stdin fifo if needs. But
+// for the container main process, the stdin fifo will be created in Create not
+// the Start call. stdinCloseSync channel should be closed after Start exec
+// process.
 func (c *client) Exec(ctx context.Context, containerID, processID string, spec *specs.Process, withStdin bool, attachStdio StdioCallback) (int, error) {
 	ctr := c.getContainer(containerID)
 	if ctr == nil {
@@ -376,7 +383,9 @@ func (c *client) Exec(ctx context.Context, containerID, processID string, spec *
 	ctr.addProcess(processID, p)
 
 	// Signal c.createIO that it can call CloseIO
-	close(stdinCloseSync)
+	//
+	// the stdin of exec process will be created after p.Start in containerd
+	defer close(stdinCloseSync)
 
 	if err = p.Start(ctx); err != nil {
 		p.Delete(context.Background())


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/38001 and https://github.com/moby/moby/pull/38016 for 18.06
fixes https://github.com/moby/moby/issues/37870 for 18.06

```
git checkout -b 18.06_backport_bugfix_issue_37870 ce-engine/18.06
git cherry-pick -s -S -x c7890f25a9eaae8d07614bd85b2b3231b03e54ec
git cherry-pick -s -S -x 8e25f4ff6d89888a1bcd578f3f8f7aab89dce24d
```

cherry-pick was clean; no conflicts


The stdin fifo of exec process is created in containerd side after
client calls Start. If the client calls CloseIO before Start call, the
stdin of exec process is still opened and wait for close.

For this case, client closes stdinCloseSync channel after Start.