### PR TITLE
[18.06 backport] Fix mount propagation for btrfs

### DIFF
--- a/pkg/mount/sharedsubtree_linux.go
+++ b/pkg/mount/sharedsubtree_linux.go
@@ -55,12 +55,9 @@ func ensureMountedAs(mountPoint, options string) error {
 	}
 
 	if !mounted {
-		if err := Mount(mountPoint, mountPoint, "none", "bind,rw"); err != nil {
+		if err := Mount(mountPoint, mountPoint, "none", "bind"); err != nil {
 			return err
 		}
-	}
-	if _, err = Mounted(mountPoint); err != nil {
-		return err
 	}
 
 	return ForceMount("", mountPoint, "none", options)

--- a/pkg/mount/sharedsubtree_linux.go
+++ b/pkg/mount/sharedsubtree_linux.go
@@ -48,16 +48,23 @@ func MakeRUnbindable(mountPoint string) error {
 	return ensureMountedAs(mountPoint, "runbindable")
 }
 
-func ensureMountedAs(mountPoint, options string) error {
-	mounted, err := Mounted(mountPoint)
+// MakeMount ensures that the file or directory given is a mount point,
+// bind mounting it to itself it case it is not.
+func MakeMount(mnt string) error {
+	mounted, err := Mounted(mnt)
 	if err != nil {
 		return err
 	}
+	if mounted {
+		return nil
+	}
 
-	if !mounted {
-		if err := Mount(mountPoint, mountPoint, "none", "bind"); err != nil {
-			return err
-		}
+	return Mount(mnt, mnt, "none", "bind")
+}
+
+func ensureMountedAs(mountPoint, options string) error {
+	if err := MakeMount(mountPoint); err != nil {
+		return err
 	}
 
 	return ForceMount("", mountPoint, "none", options)


### PR DESCRIPTION
Backport of moby#38026. Clean cherry-pick, no issues.
```
 git fetch engine
 git checkout -b 18.09-backport-btrfs-prop engine/18.09
 git cherry-pick -x f01297d1ae352bc2bf 8abadb36fa8149cd4 16d822bba8ac5ab22
 git diff engine/18.09
 git push -f kir 18.09-backport-btrfs-prop
```