### PR TITLE
[18.09 backport] builder: fix private pulls on buildkit

### DIFF
--- a/builder/builder-next/adapters/containerimage/pull.go
+++ b/builder/builder-next/adapters/containerimage/pull.go
@@ -75,12 +75,12 @@ func (is *imageSource) ID() string {
 
 func (is *imageSource) getResolver(ctx context.Context, rfn resolver.ResolveOptionsFunc, ref string) remotes.Resolver {
 	opt := docker.ResolverOptions{
-		Client:      tracing.DefaultClient,
-		Credentials: is.getCredentialsFromSession(ctx),
+		Client: tracing.DefaultClient,
 	}
 	if rfn != nil {
 		opt = rfn(ref)
 	}
+	opt.Credentials = is.getCredentialsFromSession(ctx)
 	r := docker.NewResolver(opt)
 	return r
 }


### PR DESCRIPTION
Backport of https://github.com/moby/moby/pull/38057

fixes a regression introduced in https://github.com/moby/moby/pull/37852 / https://github.com/docker/engine/pull/59


@tiborvass 

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>
(cherry picked from commit c693d45acf74b87680ace0db8615f97bd6853598)
Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>