### PR TITLE
[18.09] Add note that we use the bump_v18.09 branch for SwarmKit

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -126,7 +126,7 @@ github.com/containerd/ttrpc 2a805f71863501300ae1976d29f0454ae003e85a
 github.com/gogo/googleapis 08a7655d27152912db7aaf4f983275eaf8d128ef
 
 # cluster
-github.com/docker/swarmkit c82e409dc3175cc2a95edbccfd9cc1593a45dc35
+github.com/docker/swarmkit c82e409dc3175cc2a95edbccfd9cc1593a45dc35 # bump_v18.09 branch
 github.com/gogo/protobuf v1.0.0
 github.com/cloudflare/cfssl 1.3.2
 github.com/fernet/fernet-go 1b2437bc582b3cfbb341ee5a29f8ef5b42912ff2


### PR DESCRIPTION
Follow-up to https://github.com/docker/engine/pull/94. Let's add a note that this vendor comes from the bump_v18.09 branch, to prevent people from using a commit from upstream "master" instead.