### PR TITLE
[18.09] cluster: set bigger grpc limit for array requests

### DIFF
--- a/daemon/cluster/cluster.go
+++ b/daemon/cluster/cluster.go
@@ -41,6 +41,7 @@ package cluster // import "github.com/docker/docker/daemon/cluster"
 import (
 	"context"
 	"fmt"
+	"math"
 	"net"
 	"os"
 	"path/filepath"
@@ -67,9 +68,10 @@ const stateFile = "docker-state.json"
 const defaultAddr = "0.0.0.0:2377"
 
 const (
-	initialReconnectDelay = 100 * time.Millisecond
-	maxReconnectDelay     = 30 * time.Second
-	contextPrefix         = "com.docker.swarm"
+	initialReconnectDelay          = 100 * time.Millisecond
+	maxReconnectDelay              = 30 * time.Second
+	contextPrefix                  = "com.docker.swarm"
+	defaultRecvSizeForListResponse = math.MaxInt32 // the max recv limit grpc <1.4.0
 )
 
 // NetworkSubnetsProvider exposes functions for retrieving the subnets

--- a/daemon/cluster/services.go
+++ b/daemon/cluster/services.go
@@ -23,6 +23,7 @@ import (
 	gogotypes "github.com/gogo/protobuf/types"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
 )
 
 // GetServices returns all services of a managed swarm cluster.
@@ -67,7 +68,9 @@ func (c *Cluster) GetServices(options apitypes.ServiceListOptions) ([]types.Serv
 
 	r, err := state.controlClient.ListServices(
 		ctx,
-		&swarmapi.ListServicesRequest{Filters: filters})
+		&swarmapi.ListServicesRequest{Filters: filters},
+		grpc.MaxCallRecvMsgSize(defaultRecvSizeForListResponse),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/daemon/cluster/tasks.go
+++ b/daemon/cluster/tasks.go
@@ -8,6 +8,7 @@ import (
 	types "github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/daemon/cluster/convert"
 	swarmapi "github.com/docker/swarmkit/api"
+	"google.golang.org/grpc"
 )
 
 // GetTasks returns a list of tasks matching the filter options.
@@ -53,7 +54,9 @@ func (c *Cluster) GetTasks(options apitypes.TaskListOptions) ([]types.Task, erro
 
 		r, err = state.controlClient.ListTasks(
 			ctx,
-			&swarmapi.ListTasksRequest{Filters: filters})
+			&swarmapi.ListTasksRequest{Filters: filters},
+			grpc.MaxCallRecvMsgSize(defaultRecvSizeForListResponse),
+		)
 		return err
 	}); err != nil {
 		return nil, err


### PR DESCRIPTION
backport:
* https://github.com/moby/moby/pull/38103 cluster: set bigger grpc limit for array requests

to address:
* https://github.com/moby/moby/issues/37997 docker service ls | Error response from daemon: rpc error: code = ResourceExhausted desc = grpc: received message larger than max (5097134 vs. 4194304)

git cherry-pick https://github.com/moby/moby/pull/38103/commits/489b8eda6674523df8b82a210399b7d2954427d0

```
$ git cherry-pick -s -x 489b8eda6674523df8b82a210399b7d2954427d0
[grpc 6ca0546f25] cluster: set bigger grpc limit for array requests
 Author: Tonis Tiigi <tonistiigi@gmail.com>
 Date: Mon Oct 29 17:44:11 2018 -0700
 3 files changed, 13 insertions(+), 5 deletions(-)
```

no conflicts