### PR TITLE
[18.09 backport] Fix incorrect spelling in error message

### DIFF
--- a/daemon/logger/jsonfilelog/jsonfilelog.go
+++ b/daemon/logger/jsonfilelog/jsonfilelog.go
@@ -50,7 +50,7 @@ func New(info logger.Info) (logger.Logger, error) {
 			return nil, err
 		}
 		if capval <= 0 {
-			return nil, fmt.Errorf("max-size should be a positive numbler")
+			return nil, fmt.Errorf("max-size must be a positive number")
 		}
 	}
 	var maxFiles = 1


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/37696 for 18.09

definitely not a critical backport, but it looks... sloppy :sweat_smile:


```
git checkout -b 18.09_backport_log_error_spelling ce-engine/18.09
git cherry-pick -s -S -x f962bd06ed8824d1f75d8546b428965cd61bdf7f
```

cherry-pick was clean; no conflicts