### PR TITLE
[18.09 backport] Add more API doc details on service update version.

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -9345,7 +9345,10 @@ paths:
 
         - name: "version"
           in: "query"
-          description: "The version number of the service object being updated. This is required to avoid conflicting writes."
+          description: "The version number of the service object being updated.
+          This is required to avoid conflicting writes.
+          This version number should be the value as currently set on the service *before* the update.
+          You can find the current version by calling `GET /services/{id}`"
           required: true
           type: "integer"
         - name: "registryAuthFrom"


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/38040 for 18.09


```
git checkout -b 18.09_backport_document_service_version ce-engine/18.09
git cherry-pick -s -S -x 5bdfa19b8646839f9d704307aa6589c7d686db44
```

cherry-pick was clean; no conflicts


Hopefully this removes some confusion as to what this version number
should be.

