### PR TITLE
[18.09 backport] Fix double "unix://" scheme in TestInfoAPIWarnings

### DIFF
--- a/integration/system/info_test.go
+++ b/integration/system/info_test.go
@@ -48,7 +48,7 @@ func TestInfoAPIWarnings(t *testing.T) {
 	client, err := d.NewClient()
 	assert.NilError(t, err)
 
-	d.StartWithBusybox(t, "--iptables=false", "-H=0.0.0.0:23756", "-H=unix://"+d.Sock())
+	d.StartWithBusybox(t, "-H=0.0.0.0:23756", "-H="+d.Sock())
 	defer d.Stop(t)
 
 	info, err := client.Info(context.Background())


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/38115 for 18.09


```
git checkout -b 18.09_backport_fix_double_scheme ce-engine/18.09
git cherry-pick -s -S -x 14342046477b7ed87a9c5c451bb4520c7f6cabcc
```

cherry-pick was clean; no conflicts

`d.Sock()` already returns the socket-path including the `unix://` scheme.

Also removed `--iptables=false`, as it didn't really seem nescessary for this test.

Relates to https://github.com/moby/moby/pull/37684
