### PR TITLE
[18.09] Vendor swarmkit to 6186e40

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -126,7 +126,7 @@ github.com/containerd/ttrpc 2a805f71863501300ae1976d29f0454ae003e85a
 github.com/gogo/googleapis 08a7655d27152912db7aaf4f983275eaf8d128ef
 
 # cluster
-github.com/docker/swarmkit c82e409dc3175cc2a95edbccfd9cc1593a45dc35 # bump_v18.09 branch
+github.com/docker/swarmkit 6186e40fb04a7681e25a9101dbc7418c37ef0c8b # bump_v18.09 branch
 github.com/gogo/protobuf v1.0.0
 github.com/cloudflare/cfssl 1.3.2
 github.com/fernet/fernet-go 1b2437bc582b3cfbb341ee5a29f8ef5b42912ff2

--- a/vendor/github.com/docker/swarmkit/manager/state/raft/transport/transport.go
+++ b/vendor/github.com/docker/swarmkit/manager/state/raft/transport/transport.go
@@ -4,6 +4,7 @@ package transport
 
 import (
 	"context"
+	"math"
 	"net"
 	"sync"
 	"time"
@@ -353,6 +354,15 @@ func (t *Transport) dial(addr string) (*grpc.ClientConn, error) {
 		grpc.WithDialer(func(addr string, timeout time.Duration) (net.Conn, error) {
 			return net.DialTimeout("tcp", addr, timeout)
 		}))
+
+	// TODO(dperny): this changes the max received message size for outgoing
+	// client connections. this means if the server sends a message larger than
+	// this, we will still accept and unmarshal it. i'm unsure what the
+	// potential consequences are of setting this to be effectively unbounded,
+	// so after docker/swarmkit#2774 is fixed, we should remove this option
+	grpcOptions = append(grpcOptions, grpc.WithDefaultCallOptions(
+		grpc.MaxCallRecvMsgSize(math.MaxInt32),
+	))
 
 	cc, err := grpc.Dial(addr, grpcOptions...)
 	if err != nil {


### PR DESCRIPTION
Upstream changes: https://github.com/docker/swarmkit/compare/c82e409...6186e40

Brings in https://github.com/docker/swarmkit/pull/2775

continuation on previous fix #99 

This PR addresses the same grpc max message size issue for multi-manager swarm.

ping @andrewhsu @thaJeztah @dperny @tonistiigi 