### PR TITLE
[18.06 backport] apparmor: allow receiving of signals from 'docker kill'

### DIFF
--- a/profiles/apparmor/template.go
+++ b/profiles/apparmor/template.go
@@ -17,6 +17,12 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
   capability,
   file,
   umount,
+{{if ge .Version 208096}}
+{{/* Allow 'docker kill' to actually send signals to container processes. */}}
+  signal (receive) peer={{.DaemonProfile}},
+{{/* Allow container processes to send signals amongst themselves. */}}
+  signal (send,receive) peer={{.Name}},
+{{end}}
 
   deny @{PROC}/* w,   # deny write for all files directly in /proc (not in a subdir)
   # deny write to files not in /proc/<number>/** or /proc/sys/**


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/37831 for 18.06
Carry https://github.com/moby/moby/pull/#36822
Fixes https://github.com/moby/moby/issues/#36809

```
git checkout -b 18.06_backport_apparmor_external_templates ce-engine/18.06
git cherry-pick -s -S -x 4822fb1e2423d88cdf0ad5d039b8fd3274b05401
git push -u origin
```

cherry-pick was clean; no conflicts


In newer kernels, AppArmor will reject attempts to send signals to a
container because the signal originated from outside of that AppArmor
profile. Correct this by allowing all unconfined signals to be received.

