### PR TITLE
[18.09 backport] Ignore default address-pools on API < 1.39

### DIFF
--- a/api/server/router/swarm/cluster_routes.go
+++ b/api/server/router/swarm/cluster_routes.go
@@ -23,6 +23,12 @@ func (sr *swarmRouter) initCluster(ctx context.Context, w http.ResponseWriter, r
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		return err
 	}
+	version := httputils.VersionFromContext(ctx)
+	// DefaultAddrPool and SubnetSize were added in API 1.39. Ignore on older API versions.
+	if versions.LessThan(version, "1.39") {
+		req.DefaultAddrPool = nil
+		req.SubnetSize = 0
+	}
 	nodeID, err := sr.backend.Init(req)
 	if err != nil {
 		logrus.Errorf("Error initializing swarm: %v", err)


### PR DESCRIPTION
These options were added in API 1.39, so should be ignored when using an older version of the API.

relates to https://github.com/moby/moby/pull/37558

backport of https://github.com/moby/moby/pull/38196 for 18.09

```
git checkout -b 18.09_backport_fence_default_addr_pools ce-engine/18.09
git cherry-pick -s -S -x 7632ccbc66c82179547b96524672bd5082ae7481
git push -u origin
```

cherry-pick was clean; no conflicts

