### PR TITLE
[18.09 backport] Add missing default address pool fields to swagger

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -2459,6 +2459,22 @@ definitions:
         description: "Whether there is currently a root CA rotation in progress for the swarm"
         type: "boolean"
         example: false
+      DefaultAddrPool:
+        description: |
+          Default Address Pool specifies default subnet pools for global scope networks.
+        type: "array"
+        items:
+          type: "string"
+          format: "CIDR"
+          example: ["10.10.0.0/16", "20.20.0.0/16"]
+      SubnetSize:
+        description: |
+          SubnetSize specifies the subnet size of the networks created from the default subnet pool
+        type: "integer"
+        format: "uint32"
+        maximum: 29
+        default: 24
+        example: 24
 
   JoinTokens:
     description: |


### PR DESCRIPTION
These fields were added in https://github.com/moby/moby/pull/37558, so this will have to be back ported to docs for that version of the API

backport of https://github.com/moby/moby/pull/38218 for 18.09

```
git checkout -b 18.09_backport_fix_default_addr_pools_swagger ce-engine/18.09
git cherry-pick -s -S -x 2e8c913dbdfbba2591b6531ad2428c59eb261e0b
git push -u origin
```

cherry-pick was clean; no conflicts