### PR TITLE
[18.09 backport] BuildKit fixes for 18.09.1

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -6402,7 +6402,7 @@ paths:
           type: "string"
           description: |
             A JSON encoded value of the filters (a `map[string][]string`) to process on the list of build cache objects. Available filters:
-            - `unused-for=<duration>`: duration relative to daemon's time, during which build cache was not used, in Go's duration format (e.g., '24h')
+            - `until=<duration>`: duration relative to daemon's time, during which build cache was not used, in Go's duration format (e.g., '24h')
             - `id=<id>`
             - `parent=<id>`
             - `type=<string>`

--- a/builder/builder-next/adapters/containerimage/pull.go
+++ b/builder/builder-next/adapters/containerimage/pull.go
@@ -88,7 +88,10 @@ func (is *imageSource) getResolver(ctx context.Context, rfn resolver.ResolveOpti
 func (is *imageSource) getCredentialsFromSession(ctx context.Context) func(string) (string, string, error) {
 	id := session.FromContext(ctx)
 	if id == "" {
-		return nil
+		// can be removed after containerd/containerd#2812
+		return func(string) (string, string, error) {
+			return "", "", nil
+		}
 	}
 	return func(host string) (string, string, error) {
 		timeoutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/builder/builder-next/builder.go
+++ b/builder/builder-next/builder.go
@@ -146,6 +146,8 @@ func (b *Builder) Prune(ctx context.Context, opts types.BuildCachePruneOptions) 
 	validFilters := make(map[string]bool, 1+len(cacheFields))
 	validFilters["unused-for"] = true
 	validFilters["until"] = true
+	validFilters["label"] = true  // TODO(tiborvass): handle label
+	validFilters["label!"] = true // TODO(tiborvass): handle label!
 	for k, v := range cacheFields {
 		validFilters[k] = v
 	}

--- a/builder/builder-next/builder.go
+++ b/builder/builder-next/builder.go
@@ -2,6 +2,7 @@ package buildkit
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net"
 	"strings"
@@ -32,7 +33,21 @@ import (
 	grpcmetadata "google.golang.org/grpc/metadata"
 )
 
-var errMultipleFilterValues = errors.New("filters expect only one value")
+type errMultipleFilterValues struct{}
+
+func (errMultipleFilterValues) Error() string { return "filters expect only one value" }
+
+func (errMultipleFilterValues) InvalidParameter() {}
+
+type errConflictFilter struct {
+	a, b string
+}
+
+func (e errConflictFilter) Error() string {
+	return fmt.Sprintf("conflicting filters: %q and %q", e.a, e.b)
+}
+
+func (errConflictFilter) InvalidParameter() {}
 
 var cacheFields = map[string]bool{
 	"id":          true,
@@ -130,6 +145,7 @@ func (b *Builder) Prune(ctx context.Context, opts types.BuildCachePruneOptions) 
 
 	validFilters := make(map[string]bool, 1+len(cacheFields))
 	validFilters["unused-for"] = true
+	validFilters["until"] = true
 	for k, v := range cacheFields {
 		validFilters[k] = v
 	}
@@ -504,6 +520,7 @@ func toBuildkitExtraHosts(inp []string) (string, error) {
 	hosts := make([]string, 0, len(inp))
 	for _, h := range inp {
 		parts := strings.Split(h, ":")
+
 		if len(parts) != 2 || parts[0] == "" || net.ParseIP(parts[1]) == nil {
 			return "", errors.Errorf("invalid host %s", h)
 		}
@@ -513,21 +530,30 @@ func toBuildkitExtraHosts(inp []string) (string, error) {
 }
 
 func toBuildkitPruneInfo(opts types.BuildCachePruneOptions) (client.PruneInfo, error) {
-	var unusedFor time.Duration
-	unusedForValues := opts.Filters.Get("unused-for")
+	var until time.Duration
+	untilValues := opts.Filters.Get("until")          // canonical
+	unusedForValues := opts.Filters.Get("unused-for") // deprecated synonym for "until" filter
 
-	switch len(unusedForValues) {
+	if len(untilValues) > 0 && len(unusedForValues) > 0 {
+		return client.PruneInfo{}, errConflictFilter{"until", "unused-for"}
+	}
+	filterKey := "until"
+	if len(unusedForValues) > 0 {
+		filterKey = "unused-for"
+	}
+	untilValues = append(untilValues, unusedForValues...)
+
+	switch len(untilValues) {
 	case 0:
-
+		// nothing to do
 	case 1:
 		var err error
-		unusedFor, err = time.ParseDuration(unusedForValues[0])
+		until, err = time.ParseDuration(untilValues[0])
 		if err != nil {
-			return client.PruneInfo{}, errors.Wrap(err, "unused-for filter expects a duration (e.g., '24h')")
+			return client.PruneInfo{}, errors.Wrapf(err, "%q filter expects a duration (e.g., '24h')", filterKey)
 		}
-
 	default:
-		return client.PruneInfo{}, errMultipleFilterValues
+		return client.PruneInfo{}, errMultipleFilterValues{}
 	}
 
 	bkFilter := make([]string, 0, opts.Filters.Len())
@@ -544,13 +570,13 @@ func toBuildkitPruneInfo(opts types.BuildCachePruneOptions) (client.PruneInfo, e
 					bkFilter = append(bkFilter, cacheField+"=="+values[0])
 				}
 			default:
-				return client.PruneInfo{}, errMultipleFilterValues
+				return client.PruneInfo{}, errMultipleFilterValues{}
 			}
 		}
 	}
 	return client.PruneInfo{
 		All:          opts.All,
-		KeepDuration: unusedFor,
+		KeepDuration: until,
 		KeepBytes:    opts.KeepStorage,
 		Filter:       []string{strings.Join(bkFilter, ",")},
 	}, nil

--- a/vendor.conf
+++ b/vendor.conf
@@ -26,8 +26,8 @@ github.com/imdario/mergo v0.3.6
 golang.org/x/sync 1d60e4601c6fd243af51cc01ddf169918a5407ca
 
 # buildkit
-github.com/moby/buildkit c7bb575343df0cbfeab8b5b28149630b8153fcc6
-github.com/tonistiigi/fsutil f567071bed2416e4d87d260d3162722651182317
+github.com/moby/buildkit 8cf9bec86a7f11fe6591804aee152c8e8a7a8a0d # v0.3.3
+github.com/tonistiigi/fsutil 2862f6bc5ac9b97124e552a5c108230b38a1b0ca
 github.com/grpc-ecosystem/grpc-opentracing 8e809c8a86450a29b90dcc9efbf062d0fe6d9746
 github.com/opentracing/opentracing-go 1361b9cd60be79c4c3a7fa9841b3c132e40066a7
 github.com/google/shlex 6f45313302b9c56850fc17f99e40caebce98c716

--- a/vendor/github.com/moby/buildkit/README.md
+++ b/vendor/github.com/moby/buildkit/README.md
@@ -27,15 +27,23 @@ Read the proposal from https://github.com/moby/moby/issues/32925
 
 Introductory blog post https://blog.mobyproject.org/introducing-buildkit-17e056cc5317
 
+:information_source: If you are visiting this repo for the usage of experimental Dockerfile features like `RUN --mount=type=(bind|cache|tmpfs|secret|ssh)`, please refer to [`frontend/dockerfile/docs/experimental.md`](frontend/dockerfile/docs/experimental.md).
+
 ### Used by
 
-[Moby](https://github.com/moby/moby/pull/37151)
+[Moby & Docker](https://github.com/moby/moby/pull/37151)
 
 [img](https://github.com/genuinetools/img)
 
 [OpenFaaS Cloud](https://github.com/openfaas/openfaas-cloud)
 
 [container build interface](https://github.com/containerbuilding/cbi)
+
+[Knative Build Templates](https://github.com/knative/build-templates)
+
+[boss](https://github.com/crosbymichael/boss)
+
+[Rio](https://github.com/rancher/rio) (on roadmap)
 
 ### Quick start
 
@@ -79,6 +87,7 @@ See [`solver/pb/ops.proto`](./solver/pb/ops.proto) for the format definition.
 Currently, following high-level languages has been implemented for LLB:
 
 - Dockerfile (See [Exploring Dockerfiles](#exploring-dockerfiles))
+- [Buildpacks](https://github.com/tonistiigi/buildkit-pack)
 - (open a PR to add your own language)
 
 For understanding the basics of LLB, `examples/buildkit*` directory contains scripts that define how to build different configurations of BuildKit itself and its dependencies using the `client` package. Running one of these scripts generates a protobuf definition of a build graph. Note that the script itself does not execute any steps of the build.
@@ -145,6 +154,10 @@ buildctl build --frontend=gateway.v0 --frontend-opt=source=tonistiigi/dockerfile
 buildctl build --frontend gateway.v0 --frontend-opt=source=tonistiigi/dockerfile --frontend-opt=context=git://github.com/moby/moby --frontend-opt build-arg:APT_MIRROR=cdn-fastly.deb.debian.org
 ````
 
+##### Building a Dockerfile with experimental features like `RUN --mount=type=(bind|cache|tmpfs|secret|ssh)`
+
+See [`frontend/dockerfile/docs/experimental.md`](frontend/dockerfile/docs/experimental.md).
+
 ### Exporters
 
 By default, the build result and intermediate cache will only remain internally in BuildKit. Exporter needs to be specified to retrieve the result.
@@ -207,15 +220,22 @@ buildctl debug workers -v
 
 BuildKit can also be used by running the `buildkitd` daemon inside a Docker container and accessing it remotely. The client tool `buildctl` is also available for Mac and Windows.
 
+We provide `buildkitd` container images as [`moby/buildkit`](https://hub.docker.com/r/moby/buildkit/tags/):
+
+* `moby/buildkit:latest`: built from the latest regular [release](https://github.com/moby/buildkit/releases)
+* `moby/buildkit:rootless`: same as `latest` but runs as an unprivileged user, see [`docs/rootless.md`](docs/rootless.md)
+* `moby/buildkit:master`: built from the master branch
+* `moby/buildkit:master-rootless`: same as master but runs as an unprivileged user, see [`docs/rootless.md`](docs/rootless.md)
+
 To run daemon in a container:
 
 ```
-docker run -d --privileged -p 1234:1234 tonistiigi/buildkit --addr tcp://0.0.0.0:1234
+docker run -d --privileged -p 1234:1234 moby/buildkit:latest --addr tcp://0.0.0.0:1234
 export BUILDKIT_HOST=tcp://0.0.0.0:1234
 buildctl build --help
 ```
 
-The `tonistiigi/buildkit` image can be built locally using the Dockerfile in `./hack/dockerfiles/test.Dockerfile`.
+The images can be also built locally using `./hack/dockerfiles/test.Dockerfile` (or `./hack/dockerfiles/test.buildkit.Dockerfile` if you already have BuildKit).
 
 ### Opentracing support
 
@@ -232,7 +252,7 @@ export JAEGER_TRACE=0.0.0.0:6831
 
 ### Supported runc version
 
-During development, BuildKit is tested with the version of runc that is being used by the containerd repository. Please refer to [runc.md](https://github.com/containerd/containerd/blob/v1.1.3/RUNC.md) for more information.
+During development, BuildKit is tested with the version of runc that is being used by the containerd repository. Please refer to [runc.md](https://github.com/containerd/containerd/blob/v1.2.0-rc.1/RUNC.md) for more information.
 
 ### Running BuildKit without root privileges
 

--- a/vendor/github.com/moby/buildkit/cache/contenthash/checksum.go
+++ b/vendor/github.com/moby/buildkit/cache/contenthash/checksum.go
@@ -628,7 +628,7 @@ func getFollowLinksWalk(root *iradix.Node, k []byte, linksWalked *int) ([]byte, 
 		if dirPath == "." || dirPath == "/" {
 			dirPath = ""
 		}
-		link := parent.Linkname
+		link := path.Clean(parent.Linkname)
 		if !path.IsAbs(link) {
 			link = path.Join("/", path.Join(path.Dir(dirPath), link))
 		}

--- a/vendor/github.com/moby/buildkit/client/llb/source.go
+++ b/vendor/github.com/moby/buildkit/client/llb/source.go
@@ -126,30 +126,11 @@ func Image(ref string, opts ...ImageOption) State {
 		if err != nil {
 			src.err = err
 		} else {
-			var img struct {
-				Config struct {
-					Env        []string `json:"Env,omitempty"`
-					WorkingDir string   `json:"WorkingDir,omitempty"`
-					User       string   `json:"User,omitempty"`
-				} `json:"config,omitempty"`
-			}
-			if err := json.Unmarshal(dt, &img); err != nil {
-				src.err = err
-			} else {
-				st := NewState(src.Output())
-				for _, env := range img.Config.Env {
-					parts := strings.SplitN(env, "=", 2)
-					if len(parts[0]) > 0 {
-						var v string
-						if len(parts) > 1 {
-							v = parts[1]
-						}
-						st = st.AddEnv(parts[0], v)
-					}
-				}
-				st = st.Dir(img.Config.WorkingDir)
+			st, err := NewState(src.Output()).WithImageConfig(dt)
+			if err == nil {
 				return st
 			}
+			src.err = err
 		}
 	}
 	return NewState(src.Output())

--- a/vendor/github.com/moby/buildkit/frontend/dockerfile/builder/build.go
+++ b/vendor/github.com/moby/buildkit/frontend/dockerfile/builder/build.go
@@ -99,7 +99,7 @@ func Build(ctx context.Context, c client.Client) (*client.Result, error) {
 	name := "load build definition from " + filename
 
 	src := llb.Local(LocalNameDockerfile,
-		llb.IncludePatterns([]string{filename}),
+		llb.FollowPaths([]string{filename}),
 		llb.SessionID(c.BuildOpts().SessionID),
 		llb.SharedKeyHint(defaultDockerfileName),
 		dockerfile2llb.WithInternalName(name),
@@ -189,7 +189,7 @@ func Build(ctx context.Context, c client.Client) (*client.Result, error) {
 			if dockerignoreState == nil {
 				st := llb.Local(LocalNameContext,
 					llb.SessionID(c.BuildOpts().SessionID),
-					llb.IncludePatterns([]string{dockerignoreFilename}),
+					llb.FollowPaths([]string{dockerignoreFilename}),
 					llb.SharedKeyHint(dockerignoreFilename),
 					dockerfile2llb.WithInternalName("load "+dockerignoreFilename),
 				)

--- a/vendor/github.com/moby/buildkit/frontend/dockerfile/dockerfile2llb/convert_norunmount.go
+++ b/vendor/github.com/moby/buildkit/frontend/dockerfile/dockerfile2llb/convert_norunmount.go
@@ -1,4 +1,4 @@
-// +build !dfrunmount,!dfextall
+// +build !dfrunmount
 
 package dockerfile2llb
 

--- a/vendor/github.com/moby/buildkit/frontend/dockerfile/dockerfile2llb/convert_runmount.go
+++ b/vendor/github.com/moby/buildkit/frontend/dockerfile/dockerfile2llb/convert_runmount.go
@@ -1,4 +1,4 @@
-// +build dfrunmount dfextall
+// +build dfrunmount
 
 package dockerfile2llb
 

--- a/vendor/github.com/moby/buildkit/frontend/dockerfile/dockerfile2llb/convert_secrets.go
+++ b/vendor/github.com/moby/buildkit/frontend/dockerfile/dockerfile2llb/convert_secrets.go
@@ -1,4 +1,4 @@
-// +build dfsecrets dfextall
+// +build dfsecrets
 
 package dockerfile2llb
 

--- a/vendor/github.com/moby/buildkit/frontend/dockerfile/dockerfile2llb/convert_ssh.go
+++ b/vendor/github.com/moby/buildkit/frontend/dockerfile/dockerfile2llb/convert_ssh.go
@@ -1,4 +1,4 @@
-// +build dfssh dfextall
+// +build dfssh
 
 package dockerfile2llb
 

--- a/vendor/github.com/moby/buildkit/frontend/dockerfile/instructions/commands_nosecrets.go
+++ b/vendor/github.com/moby/buildkit/frontend/dockerfile/instructions/commands_nosecrets.go
@@ -1,4 +1,4 @@
-// +build !dfsecrets,!dfextall
+// +build !dfsecrets
 
 package instructions
 

--- a/vendor/github.com/moby/buildkit/frontend/dockerfile/instructions/commands_nossh.go
+++ b/vendor/github.com/moby/buildkit/frontend/dockerfile/instructions/commands_nossh.go
@@ -1,4 +1,4 @@
-// +build !dfssh,!dfextall
+// +build !dfssh
 
 package instructions
 

--- a/vendor/github.com/moby/buildkit/frontend/dockerfile/instructions/commands_runmount.go
+++ b/vendor/github.com/moby/buildkit/frontend/dockerfile/instructions/commands_runmount.go
@@ -1,4 +1,4 @@
-// +build dfrunmount dfextall
+// +build dfrunmount
 
 package instructions
 

--- a/vendor/github.com/moby/buildkit/frontend/dockerfile/instructions/commands_secrets.go
+++ b/vendor/github.com/moby/buildkit/frontend/dockerfile/instructions/commands_secrets.go
@@ -1,4 +1,4 @@
-// +build dfsecrets dfextall
+// +build dfsecrets
 
 package instructions
 

--- a/vendor/github.com/moby/buildkit/frontend/dockerfile/instructions/commands_ssh.go
+++ b/vendor/github.com/moby/buildkit/frontend/dockerfile/instructions/commands_ssh.go
@@ -1,4 +1,4 @@
-// +build dfssh dfextall
+// +build dfssh
 
 package instructions
 

--- a/vendor/github.com/moby/buildkit/frontend/dockerfile/shell/lex.go
+++ b/vendor/github.com/moby/buildkit/frontend/dockerfile/shell/lex.go
@@ -2,6 +2,7 @@ package shell
 
 import (
 	"bytes"
+	"fmt"
 	"strings"
 	"text/scanner"
 	"unicode"
@@ -17,7 +18,9 @@ import (
 // It doesn't support all flavors of ${xx:...} formats but new ones can
 // be added by adding code to the "special ${} format processing" section
 type Lex struct {
-	escapeToken rune
+	escapeToken  rune
+	RawQuotes    bool
+	SkipUnsetEnv bool
 }
 
 // NewLex creates a new Lex which uses escapeToken to escape quotes.
@@ -58,17 +61,21 @@ func (s *Lex) ProcessWordsWithMap(word string, env map[string]string) ([]string,
 
 func (s *Lex) process(word string, env map[string]string) (string, []string, error) {
 	sw := &shellWord{
-		envs:        env,
-		escapeToken: s.escapeToken,
+		envs:         env,
+		escapeToken:  s.escapeToken,
+		skipUnsetEnv: s.SkipUnsetEnv,
+		rawQuotes:    s.RawQuotes,
 	}
 	sw.scanner.Init(strings.NewReader(word))
 	return sw.process(word)
 }
 
 type shellWord struct {
-	scanner     scanner.Scanner
-	envs        map[string]string
-	escapeToken rune
+	scanner      scanner.Scanner
+	envs         map[string]string
+	escapeToken  rune
+	rawQuotes    bool
+	skipUnsetEnv bool
 }
 
 func (sw *shellWord) process(source string) (string, []string, error) {
@@ -103,10 +110,8 @@ func (w *wordsStruct) addRawChar(ch rune) {
 }
 
 func (w *wordsStruct) addString(str string) {
-	var scan scanner.Scanner
-	scan.Init(strings.NewReader(str))
-	for scan.Peek() != scanner.EOF {
-		w.addChar(scan.Next())
+	for _, ch := range str {
+		w.addChar(ch)
 	}
 }
 
@@ -196,14 +201,20 @@ func (sw *shellWord) processSingleQuote() (string, error) {
 
 	var result bytes.Buffer
 
-	sw.scanner.Next()
+	ch := sw.scanner.Next()
+	if sw.rawQuotes {
+		result.WriteRune(ch)
+	}
 
 	for {
-		ch := sw.scanner.Next()
+		ch = sw.scanner.Next()
 		switch ch {
 		case scanner.EOF:
 			return "", errors.New("unexpected end of statement while looking for matching single-quote")
 		case '\'':
+			if sw.rawQuotes {
+				result.WriteRune(ch)
+			}
 			return result.String(), nil
 		}
 		result.WriteRune(ch)
@@ -225,14 +236,20 @@ func (sw *shellWord) processDoubleQuote() (string, error) {
 
 	var result bytes.Buffer
 
-	sw.scanner.Next()
+	ch := sw.scanner.Next()
+	if sw.rawQuotes {
+		result.WriteRune(ch)
+	}
 
 	for {
 		switch sw.scanner.Peek() {
 		case scanner.EOF:
 			return "", errors.New("unexpected end of statement while looking for matching double-quote")
 		case '"':
-			sw.scanner.Next()
+			ch := sw.scanner.Next()
+			if sw.rawQuotes {
+				result.WriteRune(ch)
+			}
 			return result.String(), nil
 		case '$':
 			value, err := sw.processDollar()
@@ -269,7 +286,11 @@ func (sw *shellWord) processDollar() (string, error) {
 		if name == "" {
 			return "$", nil
 		}
-		return sw.getEnv(name), nil
+		value, found := sw.getEnv(name)
+		if !found && sw.skipUnsetEnv {
+			return "$" + name, nil
+		}
+		return value, nil
 	}
 
 	sw.scanner.Next()
@@ -285,7 +306,11 @@ func (sw *shellWord) processDollar() (string, error) {
 	switch ch {
 	case '}':
 		// Normal ${xx} case
-		return sw.getEnv(name), nil
+		value, found := sw.getEnv(name)
+		if !found && sw.skipUnsetEnv {
+			return fmt.Sprintf("${%s}", name), nil
+		}
+		return value, nil
 	case ':':
 		// Special ${xx:...} format processing
 		// Yes it allows for recursive $'s in the ... spot
@@ -301,12 +326,15 @@ func (sw *shellWord) processDollar() (string, error) {
 
 		// Grab the current value of the variable in question so we
 		// can use to to determine what to do based on the modifier
-		newValue := sw.getEnv(name)
+		newValue, found := sw.getEnv(name)
 
 		switch modifier {
 		case '+':
 			if newValue != "" {
 				newValue = word
+			}
+			if !found && sw.skipUnsetEnv {
+				return fmt.Sprintf("${%s:%s%s}", name, string(modifier), word), nil
 			}
 			return newValue, nil
 
@@ -314,6 +342,10 @@ func (sw *shellWord) processDollar() (string, error) {
 			if newValue == "" {
 				newValue = word
 			}
+			if !found && sw.skipUnsetEnv {
+				return fmt.Sprintf("${%s:%s%s}", name, string(modifier), word), nil
+			}
+
 			return newValue, nil
 
 		default:
@@ -364,13 +396,13 @@ func isSpecialParam(char rune) bool {
 	return false
 }
 
-func (sw *shellWord) getEnv(name string) string {
+func (sw *shellWord) getEnv(name string) (string, bool) {
 	for key, value := range sw.envs {
 		if EqualEnvKeys(name, key) {
-			return value
+			return value, true
 		}
 	}
-	return ""
+	return "", false
 }
 
 func BuildEnvs(env []string) map[string]string {

--- a/vendor/github.com/moby/buildkit/session/session.go
+++ b/vendor/github.com/moby/buildkit/session/session.go
@@ -24,7 +24,7 @@ const (
 // Dialer returns a connection that can be used by the session
 type Dialer func(ctx context.Context, proto string, meta map[string][]string) (net.Conn, error)
 
-// Attachable defines a feature that can be expsed on a session
+// Attachable defines a feature that can be exposed on a session
 type Attachable interface {
 	Register(*grpc.Server)
 }
@@ -66,7 +66,7 @@ func NewSession(ctx context.Context, name, sharedKey string) (*Session, error) {
 	return s, nil
 }
 
-// Allow enable a given service to be reachable through the grpc session
+// Allow enables a given service to be reachable through the grpc session
 func (s *Session) Allow(a Attachable) {
 	a.Register(s.grpcServer)
 }

--- a/vendor/github.com/moby/buildkit/solver/jobs.go
+++ b/vendor/github.com/moby/buildkit/solver/jobs.go
@@ -171,6 +171,7 @@ func (sb *subBuilder) Build(ctx context.Context, e Edge) (CachedResult, error) {
 }
 
 func (sb *subBuilder) Context(ctx context.Context) context.Context {
+	ctx = session.NewContext(ctx, sb.state.getSessionID())
 	return opentracing.ContextWithSpan(progress.WithProgress(ctx, sb.mpw), sb.mspan)
 }
 
@@ -475,6 +476,7 @@ func (j *Job) Discard() error {
 }
 
 func (j *Job) Context(ctx context.Context) context.Context {
+	ctx = session.NewContext(ctx, j.SessionID)
 	return progress.WithProgress(ctx, j.pw)
 }
 

--- a/vendor/github.com/moby/buildkit/util/contentutil/refs.go
+++ b/vendor/github.com/moby/buildkit/util/contentutil/refs.go
@@ -72,6 +72,7 @@ func (w *ingester) Writer(ctx context.Context, opts ...content.WriterOpt) (conte
 	}
 	writer, err := w.pusher.Push(ctx, wo.Desc)
 	if err != nil {
+		unlock()
 		return nil, err
 	}
 	return &lockedWriter{unlock: unlock, Writer: writer}, nil

--- a/vendor/github.com/moby/buildkit/util/rootless/specconv/specconv_linux.go
+++ b/vendor/github.com/moby/buildkit/util/rootless/specconv/specconv_linux.go
@@ -1,113 +1,40 @@
 package specconv
 
 import (
-	"os"
-	"sort"
 	"strings"
 
-	"github.com/opencontainers/runc/libcontainer/system"
-	"github.com/opencontainers/runc/libcontainer/user"
 	"github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
 )
 
 // ToRootless converts spec to be compatible with "rootless" runc.
-// * Adds userns (Note: since we are already in userns, ideally we should not need to do this. runc-side issue is tracked at https://github.com/opencontainers/runc/issues/1837)
-// * Fix up mount flags (same as above)
-// * Replace /sys with bind-mount (FIXME: we don't need to do this if netns is unshared)
+// * Remove /sys mount
+// * Remove cgroups
+//
+// See docs/rootless.md for the supported runc revision.
 func ToRootless(spec *specs.Spec) error {
-	if !system.RunningInUserNS() {
-		return errors.New("needs to be in user namespace")
-	}
-	uidMap, err := user.CurrentProcessUIDMap()
-	if err != nil && !os.IsNotExist(err) {
-		return err
-	}
-	gidMap, err := user.CurrentProcessUIDMap()
-	if err != nil && !os.IsNotExist(err) {
-		return err
-	}
-	return toRootless(spec, uidMap, gidMap)
-}
-
-// toRootless was forked from github.com/opencontainers/runc/libcontainer/specconv
-func toRootless(spec *specs.Spec, uidMap, gidMap []user.IDMap) error {
-	if err := configureUserNS(spec, uidMap, gidMap); err != nil {
-		return err
-	}
-	if err := configureMounts(spec); err != nil {
-		return err
-	}
-
-	// Remove cgroup settings.
-	spec.Linux.Resources = nil
-	spec.Linux.CgroupsPath = ""
-	return nil
-}
-
-// configureUserNS add suserns and the current ID map to the spec.
-// Since we are already in userns, ideally we should not need to add userns.
-// However, currently rootless runc always requires userns to be added.
-// https://github.com/opencontainers/runc/issues/1837
-func configureUserNS(spec *specs.Spec, uidMap, gidMap []user.IDMap) error {
-	spec.Linux.Namespaces = append(spec.Linux.Namespaces, specs.LinuxNamespace{
-		Type: specs.UserNamespace,
-	})
-
-	sort.Slice(uidMap, func(i, j int) bool { return uidMap[i].ID < uidMap[j].ID })
-	uNextContainerID := int64(0)
-	for _, u := range uidMap {
-		spec.Linux.UIDMappings = append(spec.Linux.UIDMappings,
-			specs.LinuxIDMapping{
-				HostID:      uint32(u.ID),
-				ContainerID: uint32(uNextContainerID),
-				Size:        uint32(u.Count),
-			})
-		uNextContainerID += int64(u.Count)
-	}
-	sort.Slice(gidMap, func(i, j int) bool { return gidMap[i].ID < gidMap[j].ID })
-	gNextContainerID := int64(0)
-	for _, g := range gidMap {
-		spec.Linux.GIDMappings = append(spec.Linux.GIDMappings,
-			specs.LinuxIDMapping{
-				HostID:      uint32(g.ID),
-				ContainerID: uint32(gNextContainerID),
-				Size:        uint32(g.Count),
-			})
-		gNextContainerID += int64(g.Count)
-	}
-	return nil
-}
-
-func configureMounts(spec *specs.Spec) error {
+	// Remove /sys mount because we can't mount /sys when the daemon netns
+	// is not unshared from the host.
+	//
+	// Instead, we could bind-mount /sys from the host, however, `rbind, ro`
+	// does not make /sys/fs/cgroup read-only (and we can't bind-mount /sys
+	// without rbind)
+	//
+	// PR for making /sys/fs/cgroup read-only is proposed, but it is very
+	// complicated: https://github.com/opencontainers/runc/pull/1869
+	//
+	// For buildkit usecase, we suppose we don't need to provide /sys to
+	// containers and remove /sys mount as a workaround.
 	var mounts []specs.Mount
 	for _, mount := range spec.Mounts {
-		// Ignore all mounts that are under /sys, because we add /sys later.
 		if strings.HasPrefix(mount.Destination, "/sys") {
 			continue
 		}
-
-		// Remove all gid= and uid= mappings.
-		// Since we are already in userns, ideally we should not need to do this.
-		// https://github.com/opencontainers/runc/issues/1837
-		var options []string
-		for _, option := range mount.Options {
-			if !strings.HasPrefix(option, "gid=") && !strings.HasPrefix(option, "uid=") {
-				options = append(options, option)
-			}
-		}
-		mount.Options = options
 		mounts = append(mounts, mount)
 	}
-
-	// Add the sysfs mount as an rbind, because we can't mount /sys unless we have netns.
-	// TODO: keep original /sys mount when we have netns.
-	mounts = append(mounts, specs.Mount{
-		Source:      "/sys",
-		Destination: "/sys",
-		Type:        "none",
-		Options:     []string{"rbind", "nosuid", "noexec", "nodev", "ro"},
-	})
 	spec.Mounts = mounts
+
+	// Remove cgroups so as to avoid `container_linux.go:337: starting container process caused "process_linux.go:280: applying cgroup configuration for process caused \"mkdir /sys/fs/cgroup/cpuset/buildkit: permission denied\""`
+	spec.Linux.Resources = nil
+	spec.Linux.CgroupsPath = ""
 	return nil
 }

--- a/vendor/github.com/moby/buildkit/vendor.conf
+++ b/vendor/github.com/moby/buildkit/vendor.conf
@@ -6,7 +6,7 @@ github.com/davecgh/go-spew v1.1.0
 github.com/pmezard/go-difflib v1.0.0
 golang.org/x/sys 1b2967e3c290b7c545b3db0deeda16e9be4f98a2
 
-github.com/containerd/containerd d97a907f7f781c0ab8340877d8e6b53cc7f1c2f6
+github.com/containerd/containerd 1a5f9a3434ac53c0e9d27093ecc588e0c281c333
 github.com/containerd/typeurl a93fcdb778cd272c6e9b3028b2f42d813e785d40
 golang.org/x/sync 450f422ab23cf9881c94e2db30cac0eb1b7cf80c
 github.com/sirupsen/logrus v1.0.0
@@ -16,9 +16,9 @@ golang.org/x/net 0ed95abb35c445290478a5348a7b38bb154135fd
 github.com/gogo/protobuf v1.0.0
 github.com/gogo/googleapis b23578765ee54ff6bceff57f397d833bf4ca6869
 github.com/golang/protobuf v1.1.0
-github.com/containerd/continuity f44b615e492bdfb371aae2f76ec694d9da1db537
+github.com/containerd/continuity bd77b46c8352f74eb12c85bdc01f4b90f69d66b4
 github.com/opencontainers/image-spec v1.0.1
-github.com/opencontainers/runc 20aff4f0488c6d4b8df4d85b4f63f1f704c11abd
+github.com/opencontainers/runc a00bf0190895aa465a5fbed0268888e2c8ddfe85
 github.com/Microsoft/go-winio v0.4.11
 github.com/containerd/fifo 3d5202aec260678c48179c56f40e6f38a095738c
 github.com/opencontainers/runtime-spec eba862dc2470385a233c7507392675cbeadf7353 # v1.0.1-45-geba862d
@@ -28,8 +28,9 @@ google.golang.org/genproto d80a6e20e776b0b17a324d0ba1ab50a39c8e8944
 golang.org/x/text 19e51611da83d6be54ddafce4a4af510cb3e9ea4
 github.com/docker/go-events 9461782956ad83b30282bf90e31fa6a70c255ba9
 github.com/syndtr/gocapability db04d3cc01c8b54962a58ec7e491717d06cfcc16
-github.com/Microsoft/hcsshim v0.7.3
+github.com/Microsoft/hcsshim v0.7.9
 golang.org/x/crypto 0709b304e793a5edb4a2c0145f281ecdc20838a4
+github.com/containerd/cri 8506fe836677cc3bb23a16b68145128243d843b5 # release/1.2 branch
 
 github.com/urfave/cli 7bc6a0acffa589f415f88aca16cc1de5ffd66f9c
 github.com/morikuni/aec 39771216ff4c63d11f5e604076f9c45e8be1067b
@@ -40,8 +41,8 @@ golang.org/x/time f51c12702a4d776e4c1fa9b0fabab841babae631
 github.com/docker/docker 71cd53e4a197b303c6ba086bd584ffd67a884281
 github.com/pkg/profile 5b67d428864e92711fcbd2f8629456121a56d91f
 
-github.com/tonistiigi/fsutil f567071bed2416e4d87d260d3162722651182317
-github.com/hashicorp/go-immutable-radix 826af9ccf0feeee615d546d69b11f8e98da8c8f1 git://github.com/tonistiigi/go-immutable-radix.git
+github.com/tonistiigi/fsutil 2862f6bc5ac9b97124e552a5c108230b38a1b0ca
+github.com/hashicorp/go-immutable-radix 826af9ccf0feeee615d546d69b11f8e98da8c8f1 https://github.com/tonistiigi/go-immutable-radix
 github.com/hashicorp/golang-lru a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4
 github.com/mitchellh/hashstructure 2bca23e0e452137f789efbc8610126fd8b94f73b
 github.com/docker/go-connections 3ede32e2033de7505e6500d6c868c2b9ed9f169d
@@ -66,6 +67,3 @@ github.com/opentracing-contrib/go-stdlib b1a47cfbdd7543e70e9ef3e73d0802ad306cc1c
 # used by dockerfile tests
 gotest.tools v2.1.0
 github.com/google/go-cmp v0.2.0
-
-# used by rootless spec conv test
-github.com/seccomp/libseccomp-golang 32f571b70023028bd57d9288c20efbcb237f3ce0


### PR DESCRIPTION
Brings in following:

- fix docker system prune doesn't accept until filter https://github.com/moby/moby/pull/38238
- builder: avoid unset credentials in containerd https://github.com/moby/moby/pull/38226
- update buildkit to 0.3.3 https://github.com/moby/moby/pull/38244 , fixing:
   - dockerfile: disable network for copy moby/buildkit#697
   - fix private repos config resolve with external frontends moby/buildkit#729
   - fix symlinks on reading Dockerfile moby/buildkit#733
   - fix copying absolute symlinks moby/buildkit#712

Possibly could also use "builder: add workaround for gcr auth issue"  https://github.com/moby/moby/pull/38246 but needs upstream reviews first

@tiborvass @thaJeztah 