### PR TITLE
[18.09] builder: set externalkey option for faster hook processing

### DIFF
--- a/builder/builder-next/executor_unix.go
+++ b/builder/builder-next/executor_unix.go
@@ -15,6 +15,7 @@ import (
 	"github.com/moby/buildkit/solver/pb"
 	"github.com/moby/buildkit/util/network"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/sirupsen/logrus"
 )
 
 const networkName = "bridge"
@@ -100,10 +101,10 @@ func (iface *lnInterface) Set(s *specs.Spec) {
 
 func (iface *lnInterface) Close() error {
 	<-iface.ready
-	err := iface.sbx.Delete()
-	if iface.err != nil {
-		// iface.err takes precedence over cleanup errors
-		return iface.err
-	}
-	return err
+	go func() {
+		if err := iface.sbx.Delete(); err != nil {
+			logrus.Errorf("failed to delete builder network sandbox: %v", err)
+		}
+	}()
+	return iface.err
 }

--- a/builder/builder-next/executor_unix.go
+++ b/builder/builder-next/executor_unix.go
@@ -63,13 +63,13 @@ func (iface *lnInterface) init(c libnetwork.NetworkController, n libnetwork.Netw
 	defer close(iface.ready)
 	id := identity.NewID()
 
-	ep, err := n.CreateEndpoint(id)
+	ep, err := n.CreateEndpoint(id, libnetwork.CreateOptionDisableResolution())
 	if err != nil {
 		iface.err = err
 		return
 	}
 
-	sbx, err := c.NewSandbox(id)
+	sbx, err := c.NewSandbox(id, libnetwork.OptionUseExternalKey())
 	if err != nil {
 		iface.err = err
 		return


### PR DESCRIPTION
backport https://github.com/moby/moby/pull/38291

@thaJeztah @andrewhsu @tiborvass @fcrisciani 

This is a regression in `18.09` as `18.06-experimental` used host networking.