### PR TITLE
[18.09 backport] Masked /proc/asound

### DIFF
--- a/oci/defaults.go
+++ b/oci/defaults.go
@@ -114,6 +114,7 @@ func DefaultLinuxSpec() specs.Spec {
 
 	s.Linux = &specs.Linux{
 		MaskedPaths: []string{
+			"/proc/asound",
 			"/proc/acpi",
 			"/proc/kcore",
 			"/proc/keys",
@@ -125,7 +126,6 @@ func DefaultLinuxSpec() specs.Spec {
 			"/sys/firmware",
 		},
 		ReadonlyPaths: []string{
-			"/proc/asound",
 			"/proc/bus",
 			"/proc/fs",
 			"/proc/irq",


### PR DESCRIPTION
Backport of https://github.com/moby/moby/pull/38299 for the 18.09 branch
fixes https://github.com/moby/moby/issues/38285 for 18.09 

```
git checkout -b 18.09_backport_mask_asound ce-engine/18.09
git cherry-pick -s -S -x 64e52ff3dbdb31adc0a9930b3ea74b04b0df8d86
git push -u origin
```

cherry-pick was clean; no conflicts


While looking through the Moby source code was found /proc/asound to be shared
with containers as read-only.

This can lead to two information leaks.

---

**Leak of media playback status of the host**

Steps to reproduce the issue:

 - Listen to music/Play a YouTube video/Do anything else that involves sound
   output
 - Execute docker run --rm ubuntu:latest bash -c "sleep 7; cat
   /proc/asound/card*/pcm*p/sub*/status | grep state | cut -d ' ' -f2 | grep
   RUNNING || echo 'not running'"
 - See that the containerized process is able to check whether someone on the
   host is playing music as it prints RUNNING
 - Stop the music output
 - Execute the command again (The sleep is delaying the output because
   information regarding playback status isn't propagated instantly)
 - See that it outputs not running

**Describe the results you received:**

A containerized process is able to gather information on the playback
status of an audio device governed by the host. Therefore a process of a
container is able to check whether and what kind of user activity is
present on the host system. Also, this may indicate whether a container
runs on a desktop system or a server as media playback rarely happens on
server systems.

The description above is in regard to media playback - when examining
`/proc/asound/card*/pcm*c/sub*/status` (`pcm*c` instead of `pcm*p`) this
can also leak information regarding capturing sound, as in recording
audio or making calls on the host system.
