### PR TITLE
[18.09 backport] update containerd vendoring to v1.2.1

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -1480,7 +1480,7 @@ func (daemon *Daemon) initCgroupsPath(path string) error {
 	// for the period and runtime as this limits what the children can be set to.
 	daemon.initCgroupsPath(filepath.Dir(path))
 
-	mnt, root, err := cgroups.FindCgroupMountpointAndRoot("cpu")
+	mnt, root, err := cgroups.FindCgroupMountpointAndRoot("", "cpu")
 	if err != nil {
 		return err
 	}

--- a/hack/dockerfile/install/proxy.installer
+++ b/hack/dockerfile/install/proxy.installer
@@ -3,7 +3,7 @@
 # LIBNETWORK_COMMIT is used to build the docker-userland-proxy binary. When
 # updating the binary version, consider updating github.com/docker/libnetwork
 # in vendor.conf accordingly
-LIBNETWORK_COMMIT=8bc51fd276b549b106dbc7bf8ab18b3a01d66e64 # bump_18.09 branch
+LIBNETWORK_COMMIT=2cfbf9b1f98162a55829a21cc603c76072a75382 # bump_18.09 branch
 
 install_proxy() {
 	case "$1" in

--- a/pkg/sysinfo/sysinfo_linux.go
+++ b/pkg/sysinfo/sysinfo_linux.go
@@ -227,7 +227,7 @@ func checkCgroupCpusetInfo(cgMounts map[string]string, quiet bool) cgroupCpusetI
 
 // checkCgroupPids reads the pids information from the pids cgroup mount point.
 func checkCgroupPids(quiet bool) cgroupPids {
-	_, err := cgroups.FindCgroupMountpoint("pids")
+	_, err := cgroups.FindCgroupMountpoint("", "pids")
 	if err != nil {
 		if !quiet {
 			logrus.Warn(err)

--- a/vendor.conf
+++ b/vendor.conf
@@ -37,7 +37,7 @@ github.com/mitchellh/hashstructure 2bca23e0e452137f789efbc8610126fd8b94f73b
 #get libnetwork packages
 
 # When updating, also update LIBNETWORK_COMMIT in hack/dockerfile/install/proxy accordingly
-github.com/docker/libnetwork 8bc51fd276b549b106dbc7bf8ab18b3a01d66e64 # bump_18.09 branch
+github.com/docker/libnetwork 2cfbf9b1f98162a55829a21cc603c76072a75382 # bump_18.09 branch
 github.com/docker/go-events 9461782956ad83b30282bf90e31fa6a70c255ba9
 github.com/armon/go-radix e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec

--- a/vendor.conf
+++ b/vendor.conf
@@ -79,7 +79,7 @@ google.golang.org/grpc v1.12.0
 # the containerd project first, and update both after that is merged.
 # This commit does not need to match RUNC_COMMIT as it is used for helper
 # packages but should be newer or equal.
-github.com/opencontainers/runc 10d38b660a77168360df3522881e2dc2be5056bd
+github.com/opencontainers/runc 96ec2177ae841256168fcf76954f7177af9446eb
 github.com/opencontainers/runtime-spec 5684b8af48c1ac3b1451fa499724e30e3c20a294 # v1.0.1-49-g5684b8a
 github.com/opencontainers/image-spec v1.0.1
 github.com/seccomp/libseccomp-golang 32f571b70023028bd57d9288c20efbcb237f3ce0
@@ -118,12 +118,12 @@ github.com/googleapis/gax-go v2.0.0
 google.golang.org/genproto 694d95ba50e67b2e363f3483057db5d4910c18f9
 
 # containerd
-github.com/containerd/containerd de1f167ab96338a9f5c2b17347abf84bdf1dd411 # v1.2.1-rc.0
+github.com/containerd/containerd 9b32062dc1f5a7c2564315c269b5059754f12b9d # v1.2.1
 github.com/containerd/fifo 3d5202aec260678c48179c56f40e6f38a095738c
 github.com/containerd/continuity bd77b46c8352f74eb12c85bdc01f4b90f69d66b4
 github.com/containerd/cgroups 5e610833b72089b37d0e615de9a92dfc043757c2
 github.com/containerd/console c12b1e7919c14469339a5d38f2f8ed9b64a9de23
-github.com/containerd/cri f913714917d2456d7e65a0be84962b1ce8acb487 # release/1.2 branch
+github.com/containerd/cri 0ca1e3c2b73b5c38e72f29bb76338d0078b23d6c # release/1.2 branch
 github.com/containerd/go-runc 5a6d9f37cfa36b15efba46dc7ea349fa9b7143c3
 github.com/containerd/typeurl a93fcdb778cd272c6e9b3028b2f42d813e785d40
 github.com/containerd/ttrpc 2a805f71863501300ae1976d29f0454ae003e85a

--- a/vendor/github.com/containerd/containerd/oci/spec.go
+++ b/vendor/github.com/containerd/containerd/oci/spec.go
@@ -209,6 +209,7 @@ func populateDefaultUnixSpec(ctx context.Context, s *Spec, id string) error {
 		Linux: &specs.Linux{
 			MaskedPaths: []string{
 				"/proc/acpi",
+				"/proc/asound",
 				"/proc/kcore",
 				"/proc/keys",
 				"/proc/latency_stats",
@@ -219,7 +220,6 @@ func populateDefaultUnixSpec(ctx context.Context, s *Spec, id string) error {
 				"/proc/scsi",
 			},
 			ReadonlyPaths: []string{
-				"/proc/asound",
 				"/proc/bus",
 				"/proc/fs",
 				"/proc/irq",

--- a/vendor/github.com/containerd/containerd/runtime/v1/linux/proc/deleted_state.go
+++ b/vendor/github.com/containerd/containerd/runtime/v1/linux/proc/deleted_state.go
@@ -69,3 +69,7 @@ func (s *deletedState) SetExited(status int) {
 func (s *deletedState) Exec(ctx context.Context, path string, r *ExecConfig) (proc.Process, error) {
 	return nil, errors.Errorf("cannot exec in a deleted state")
 }
+
+func (s *deletedState) Pid() int {
+	return -1
+}

--- a/vendor/github.com/containerd/containerd/runtime/v1/linux/proc/exec.go
+++ b/vendor/github.com/containerd/containerd/runtime/v1/linux/proc/exec.go
@@ -69,8 +69,10 @@ func (e *execProcess) ID() string {
 }
 
 func (e *execProcess) Pid() int {
-	e.mu.Lock()
-	defer e.mu.Unlock()
+	return e.execState.Pid()
+}
+
+func (e *execProcess) pidv() int {
 	return e.pid
 }
 

--- a/vendor/github.com/containerd/containerd/runtime/v1/linux/proc/exec_state.go
+++ b/vendor/github.com/containerd/containerd/runtime/v1/linux/proc/exec_state.go
@@ -31,6 +31,7 @@ type execState interface {
 	Delete(context.Context) error
 	Kill(context.Context, uint32, bool) error
 	SetExited(int)
+	Pid() int
 }
 
 type execCreatedState struct {
@@ -82,6 +83,12 @@ func (s *execCreatedState) SetExited(status int) {
 	}
 }
 
+func (s *execCreatedState) Pid() int {
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
+	return s.p.pidv()
+}
+
 type execRunningState struct {
 	p *execProcess
 }
@@ -120,6 +127,12 @@ func (s *execRunningState) SetExited(status int) {
 	}
 }
 
+func (s *execRunningState) Pid() int {
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
+	return s.p.pidv()
+}
+
 type execStoppedState struct {
 	p *execProcess
 }
@@ -156,4 +169,8 @@ func (s *execStoppedState) Kill(ctx context.Context, sig uint32, all bool) error
 
 func (s *execStoppedState) SetExited(status int) {
 	// no op
+}
+
+func (s *execStoppedState) Pid() int {
+	return s.p.pidv()
 }

--- a/vendor/github.com/containerd/containerd/runtime/v1/linux/proc/init_state.go
+++ b/vendor/github.com/containerd/containerd/runtime/v1/linux/proc/init_state.go
@@ -24,7 +24,6 @@ import (
 	"syscall"
 
 	"github.com/containerd/console"
-	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/runtime/proc"
 	"github.com/containerd/fifo"
 	runc "github.com/containerd/go-runc"
@@ -407,7 +406,7 @@ func (s *stoppedState) Delete(ctx context.Context) error {
 }
 
 func (s *stoppedState) Kill(ctx context.Context, sig uint32, all bool) error {
-	return errdefs.ToGRPCf(errdefs.ErrNotFound, "process %s not found", s.p.id)
+	return s.p.kill(ctx, sig, all)
 }
 
 func (s *stoppedState) SetExited(status int) {

--- a/vendor/github.com/containerd/containerd/runtime/v1/linux/proc/utils.go
+++ b/vendor/github.com/containerd/containerd/runtime/v1/linux/proc/utils.go
@@ -93,7 +93,9 @@ func checkKillError(err error) error {
 	if err == nil {
 		return nil
 	}
-	if strings.Contains(err.Error(), "os: process already finished") || err == unix.ESRCH {
+	if strings.Contains(err.Error(), "os: process already finished") ||
+		strings.Contains(err.Error(), "container not running") ||
+		err == unix.ESRCH {
 		return errors.Wrapf(errdefs.ErrNotFound, "process already finished")
 	}
 	return errors.Wrapf(err, "unknown error after kill")

--- a/vendor/github.com/containerd/containerd/vendor.conf
+++ b/vendor/github.com/containerd/containerd/vendor.conf
@@ -20,7 +20,7 @@ github.com/gogo/protobuf v1.0.0
 github.com/gogo/googleapis 08a7655d27152912db7aaf4f983275eaf8d128ef
 github.com/golang/protobuf v1.1.0
 github.com/opencontainers/runtime-spec eba862dc2470385a233c7507392675cbeadf7353 # v1.0.1-45-geba862d
-github.com/opencontainers/runc 10d38b660a77168360df3522881e2dc2be5056bd
+github.com/opencontainers/runc 96ec2177ae841256168fcf76954f7177af9446eb
 github.com/sirupsen/logrus v1.0.0
 github.com/urfave/cli 7bc6a0acffa589f415f88aca16cc1de5ffd66f9c
 golang.org/x/net b3756b4b77d7b13260a0a2ec658753cf48922eac
@@ -43,7 +43,7 @@ github.com/google/go-cmp v0.1.0
 go.etcd.io/bbolt v1.3.1-etcd.8
 
 # cri dependencies
-github.com/containerd/cri 2bb57d27203d82fc79c496aea724aec593b2705a # release/1.2 branch
+github.com/containerd/cri 0ca1e3c2b73b5c38e72f29bb76338d0078b23d6c # release/1.2 branch
 github.com/containerd/go-cni 40bcf8ec8acd7372be1d77031d585d5d8e561c90
 github.com/blang/semver v3.1.0
 github.com/containernetworking/cni v0.6.0

--- a/vendor/github.com/containerd/cri/vendor.conf
+++ b/vendor/github.com/containerd/cri/vendor.conf
@@ -3,7 +3,7 @@ github.com/blang/semver v3.1.0
 github.com/BurntSushi/toml a368813c5e648fee92e5f6c30e3944ff9d5e8895
 github.com/containerd/cgroups 5e610833b72089b37d0e615de9a92dfc043757c2
 github.com/containerd/console c12b1e7919c14469339a5d38f2f8ed9b64a9de23
-github.com/containerd/containerd 15f19d7a67fa322e6de0ef4c6a1bf9da0f056554
+github.com/containerd/containerd 4b284fa3ab61832b022ba428055f793a75ffc251
 github.com/containerd/continuity bd77b46c8352f74eb12c85bdc01f4b90f69d66b4
 github.com/containerd/fifo 3d5202aec260678c48179c56f40e6f38a095738c
 github.com/containerd/go-cni 40bcf8ec8acd7372be1d77031d585d5d8e561c90
@@ -33,13 +33,13 @@ github.com/hashicorp/errwrap 7554cd9344cec97297fa6649b055a8c98c2a1e55
 github.com/hashicorp/go-multierror ed905158d87462226a13fe39ddf685ea65f1c11f
 github.com/json-iterator/go 1.1.5
 github.com/matttproud/golang_protobuf_extensions v1.0.0
-github.com/Microsoft/go-winio v0.4.10
-github.com/Microsoft/hcsshim v0.7.6
+github.com/Microsoft/go-winio v0.4.11
+github.com/Microsoft/hcsshim v0.8.1
 github.com/modern-go/concurrent 1.0.3
 github.com/modern-go/reflect2 1.0.1
 github.com/opencontainers/go-digest c9281466c8b2f606084ac71339773efd177436e7
 github.com/opencontainers/image-spec v1.0.1
-github.com/opencontainers/runc 00dc70017d222b178a002ed30e9321b12647af2d
+github.com/opencontainers/runc v1.0.0-rc6
 github.com/opencontainers/runtime-spec eba862dc2470385a233c7507392675cbeadf7353
 github.com/opencontainers/runtime-tools v0.6.0
 github.com/opencontainers/selinux b6fa367ed7f534f9ba25391cc2d467085dbb445a

--- a/vendor/github.com/docker/libnetwork/sandbox_externalkey_unix.go
+++ b/vendor/github.com/docker/libnetwork/sandbox_externalkey_unix.go
@@ -11,7 +11,7 @@ import (
 	"os"
 
 	"github.com/docker/libnetwork/types"
-	"github.com/opencontainers/runc/libcontainer/configs"
+	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
 )
 
@@ -20,7 +20,7 @@ const success = "success"
 
 // processSetKeyReexec is a private function that must be called only on an reexec path
 // It expects 3 args { [0] = "libnetwork-setkey", [1] = <container-id>, [2] = <controller-id> }
-// It also expects configs.HookState as a json string in <stdin>
+// It also expects specs.State as a json string in <stdin>
 // Refer to https://github.com/opencontainers/runc/pull/160/ for more information
 func processSetKeyReexec() {
 	var err error
@@ -39,12 +39,12 @@ func processSetKeyReexec() {
 	}
 	containerID := os.Args[1]
 
-	// We expect configs.HookState as a json string in <stdin>
+	// We expect specs.State as a json string in <stdin>
 	stateBuf, err := ioutil.ReadAll(os.Stdin)
 	if err != nil {
 		return
 	}
-	var state configs.HookState
+	var state specs.State
 	if err = json.Unmarshal(stateBuf, &state); err != nil {
 		return
 	}

--- a/vendor/github.com/docker/libnetwork/vendor.conf
+++ b/vendor/github.com/docker/libnetwork/vendor.conf
@@ -32,7 +32,7 @@ github.com/mattn/go-shellwords v1.0.3
 github.com/miekg/dns v1.0.7
 github.com/opencontainers/go-digest v1.0.0-rc1
 github.com/opencontainers/image-spec v1.0.1
-github.com/opencontainers/runc 69663f0bd4b60df09991c08812a60108003fa340
+github.com/opencontainers/runc 96ec2177ae841256168fcf76954f7177af9446eb
 github.com/opencontainers/runtime-spec v1.0.1
 github.com/samuel/go-zookeeper d0e0d8e11f318e000a8cc434616d69e329edc374
 github.com/sirupsen/logrus v1.0.3

--- a/vendor/github.com/opencontainers/runc/libcontainer/configs/config.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/configs/config.go
@@ -272,26 +272,23 @@ func (hooks Hooks) MarshalJSON() ([]byte, error) {
 	})
 }
 
-// HookState is the payload provided to a hook on execution.
-type HookState specs.State
-
 type Hook interface {
 	// Run executes the hook with the provided state.
-	Run(HookState) error
+	Run(*specs.State) error
 }
 
 // NewFunctionHook will call the provided function when the hook is run.
-func NewFunctionHook(f func(HookState) error) FuncHook {
+func NewFunctionHook(f func(*specs.State) error) FuncHook {
 	return FuncHook{
 		run: f,
 	}
 }
 
 type FuncHook struct {
-	run func(HookState) error
+	run func(*specs.State) error
 }
 
-func (f FuncHook) Run(s HookState) error {
+func (f FuncHook) Run(s *specs.State) error {
 	return f.run(s)
 }
 
@@ -314,7 +311,7 @@ type CommandHook struct {
 	Command
 }
 
-func (c Command) Run(s HookState) error {
+func (c Command) Run(s *specs.State) error {
 	b, err := json.Marshal(s)
 	if err != nil {
 		return err

--- a/vendor/github.com/opencontainers/runc/libcontainer/configs/intelrdt.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/configs/intelrdt.go
@@ -5,7 +5,9 @@ type IntelRdt struct {
 	// Format: "L3:<cache_id0>=<cbm0>;<cache_id1>=<cbm1>;..."
 	L3CacheSchema string `json:"l3_cache_schema,omitempty"`
 
-	// The schema of memory bandwidth percentage per L3 cache id
+	// The schema of memory bandwidth per L3 cache id
 	// Format: "MB:<cache_id0>=bandwidth0;<cache_id1>=bandwidth1;..."
+	// The unit of memory bandwidth is specified in "percentages" by
+	// default, and in "MBps" if MBA Software Controller is enabled.
 	MemBwSchema string `json:"memBwSchema,omitempty"`
 }


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/38327 for 18.09

conflict in second commit (libnetwork vendor.conf), which is expected due to 18.09 vendoring from the bump_18.09 branch


ping @crosbymichael @andrewhsu @tiborvass @vdemeester PTAL