### PR TITLE
[18.09 backport] API: fix status code on conflicting service names

### DIFF
--- a/integration/internal/swarm/service.go
+++ b/integration/internal/swarm/service.go
@@ -66,24 +66,27 @@ type ServiceSpecOpt func(*swarmtypes.ServiceSpec)
 // CreateService creates a service on the passed in swarm daemon.
 func CreateService(t *testing.T, d *daemon.Daemon, opts ...ServiceSpecOpt) string {
 	t.Helper()
-	spec := defaultServiceSpec()
-	for _, o := range opts {
-		o(&spec)
-	}
 
 	client := d.NewClientT(t)
 	defer client.Close()
 
+	spec := CreateServiceSpec(t, opts...)
 	resp, err := client.ServiceCreate(context.Background(), spec, types.ServiceCreateOptions{})
 	assert.NilError(t, err, "error creating service")
 	return resp.ID
 }
 
-func defaultServiceSpec() swarmtypes.ServiceSpec {
+// CreateServiceSpec creates a default service-spec, and applies the provided options
+func CreateServiceSpec(t *testing.T, opts ...ServiceSpecOpt) swarmtypes.ServiceSpec {
+	t.Helper()
 	var spec swarmtypes.ServiceSpec
 	ServiceWithImage("busybox:latest")(&spec)
 	ServiceWithCommand([]string{"/bin/top"})(&spec)
 	ServiceWithReplicas(1)(&spec)
+
+	for _, o := range opts {
+		o(&spec)
+	}
 	return spec
 }
 

--- a/integration/service/create_test.go
+++ b/integration/service/create_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"net/http"
 	"testing"
 	"time"
 
@@ -14,6 +15,7 @@ import (
 	"github.com/docker/docker/integration/internal/network"
 	"github.com/docker/docker/integration/internal/swarm"
 	"github.com/docker/docker/internal/test/daemon"
+	"github.com/docker/docker/internal/test/request"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
 	"gotest.tools/poll"
@@ -120,6 +122,34 @@ func TestCreateServiceMultipleTimes(t *testing.T) {
 	assert.NilError(t, err)
 
 	poll.WaitOn(t, networkIsRemoved(client, overlayID), poll.WithTimeout(1*time.Minute), poll.WithDelay(10*time.Second))
+}
+
+func TestCreateServiceConflict(t *testing.T) {
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
+	defer setupTest(t)()
+	d := swarm.NewSwarm(t, testEnv)
+	defer d.Stop(t)
+
+	serviceName := "TestService_" + t.Name()
+	serviceSpec := []swarm.ServiceSpecOpt{
+		swarm.ServiceWithName(serviceName),
+	}
+
+	swarm.CreateService(t, d, serviceSpec...)
+
+	spec := swarm.CreateServiceSpec(t, serviceSpec...)
+	res, body, err := request.Post(
+		"/services/create",
+		request.Host(d.Sock()),
+		request.JSONBody(spec),
+		request.JSON,
+	)
+	assert.NilError(t, err)
+	assert.Equal(t, res.StatusCode, http.StatusConflict)
+
+	buf, err := request.ReadBody(body)
+	assert.NilError(t, err)
+	assert.Check(t, is.Contains(string(buf), "service "+serviceName+" already exists"))
 }
 
 func TestCreateWithDuplicateNetworkNames(t *testing.T) {

--- a/vendor.conf
+++ b/vendor.conf
@@ -130,7 +130,7 @@ github.com/containerd/ttrpc 2a805f71863501300ae1976d29f0454ae003e85a
 github.com/gogo/googleapis 08a7655d27152912db7aaf4f983275eaf8d128ef
 
 # cluster
-github.com/docker/swarmkit 6186e40fb04a7681e25a9101dbc7418c37ef0c8b # bump_v18.09 branch
+github.com/docker/swarmkit d61ff7666d7eba47137060c6c8fa8c29aa6198f5 # bump_v18.09 branch
 github.com/gogo/protobuf v1.0.0
 github.com/cloudflare/cfssl 1.3.2
 github.com/fernet/fernet-go 1b2437bc582b3cfbb341ee5a29f8ef5b42912ff2


### PR DESCRIPTION
Backports of;

- https://github.com/moby/moby/pull/38142 API: Add test for status code on conflicting service names
- https://github.com/docker/swarmkit/pull/2779 Return correct error-codes on conflicting names


Updates swarmkit to the latest version in the bump_18.09 branch;

https://github.com/docker/swarmkit/compare/6186e40fb04a7681e25a9101dbc7418c37ef0c8b...d61ff7666d7eba47137060c6c8fa8c29aa6198f5
  - https://github.com/docker/swarmkit/pull/2788 Return correct error-codes on conflicting names (backport of https://github.com/docker/swarmkit/pull/2779)
  - Addresses https://github.com/moby/moby/issues/38140. Relates to https://github.com/moby/moby/pull/38142 


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
```Markdown
- Fix API return code for conflicting service names [docker/engine#130](https://github.com/docker/engine/pull/130)
```


