### PR TITLE
vendor: update buildkit to d9f75920

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -26,7 +26,7 @@ github.com/imdario/mergo v0.3.6
 golang.org/x/sync 1d60e4601c6fd243af51cc01ddf169918a5407ca
 
 # buildkit
-github.com/moby/buildkit 8cf9bec86a7f11fe6591804aee152c8e8a7a8a0d # v0.3.3
+github.com/moby/buildkit d9f75920678e35090025bb89344c5370e2efc8e7
 github.com/tonistiigi/fsutil 2862f6bc5ac9b97124e552a5c108230b38a1b0ca
 github.com/grpc-ecosystem/grpc-opentracing 8e809c8a86450a29b90dcc9efbf062d0fe6d9746
 github.com/opentracing/opentracing-go 1361b9cd60be79c4c3a7fa9841b3c132e40066a7

--- a/vendor/github.com/moby/buildkit/README.md
+++ b/vendor/github.com/moby/buildkit/README.md
@@ -145,13 +145,13 @@ build-using-dockerfile -t mybuildkit -f ./hack/dockerfiles/test.Dockerfile .
 docker inspect myimage
 ```
 
-##### Building a Dockerfile using [external frontend](https://hub.docker.com/r/tonistiigi/dockerfile/tags/):
+##### Building a Dockerfile using [external frontend](https://hub.docker.com/r/docker/dockerfile/tags/):
 
-During development, an external version of the Dockerfile frontend is pushed to https://hub.docker.com/r/tonistiigi/dockerfile that can be used with the gateway frontend. The source for the external frontend is currently located in `./frontend/dockerfile/cmd/dockerfile-frontend` but will move out of this repository in the future ([#163](https://github.com/moby/buildkit/issues/163)). For automatic build from master branch of this repository `tonistiigi/dockerfile:master` image can be used.
+External versions of the Dockerfile frontend are pushed to https://hub.docker.com/r/docker/dockerfile-upstream and https://hub.docker.com/r/docker/dockerfile and can be used with the gateway frontend. The source for the external frontend is currently located in `./frontend/dockerfile/cmd/dockerfile-frontend` but will move out of this repository in the future ([#163](https://github.com/moby/buildkit/issues/163)). For automatic build from master branch of this repository `docker/dockerfile-upsteam:master` or `docker/dockerfile-upstream:master-experimental` image can be used.
 
 ```
-buildctl build --frontend=gateway.v0 --frontend-opt=source=tonistiigi/dockerfile --local context=. --local dockerfile=.
-buildctl build --frontend gateway.v0 --frontend-opt=source=tonistiigi/dockerfile --frontend-opt=context=git://github.com/moby/moby --frontend-opt build-arg:APT_MIRROR=cdn-fastly.deb.debian.org
+buildctl build --frontend=gateway.v0 --frontend-opt=source=docker/dockerfile --local context=. --local dockerfile=.
+buildctl build --frontend gateway.v0 --frontend-opt=source=docker/dockerfile --frontend-opt=context=git://github.com/moby/moby --frontend-opt build-arg:APT_MIRROR=cdn-fastly.deb.debian.org
 ````
 
 ##### Building a Dockerfile with experimental features like `RUN --mount=type=(bind|cache|tmpfs|secret|ssh)`

--- a/vendor/github.com/moby/buildkit/executor/oci/spec_unix.go
+++ b/vendor/github.com/moby/buildkit/executor/oci/spec_unix.go
@@ -44,7 +44,8 @@ func GenerateSpec(ctx context.Context, meta executor.Meta, mounts []executor.Mou
 	s.Process.Args = meta.Args
 	s.Process.Env = meta.Env
 	s.Process.Cwd = meta.Cwd
-	s.Process.Rlimits = nil // reset open files limit
+	s.Process.Rlimits = nil           // reset open files limit
+	s.Process.NoNewPrivileges = false // reset nonewprivileges
 	s.Hostname = "buildkitsandbox"
 
 	s.Mounts = GetMounts(ctx,

--- a/vendor/github.com/moby/buildkit/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/vendor/github.com/moby/buildkit/frontend/dockerfile/dockerfile2llb/convert.go
@@ -250,7 +250,6 @@ func Dockerfile2LLB(ctx context.Context, dt []byte, opt ConvertOpt) (*llb.State,
 								}
 							}
 							d.stage.BaseName = ref.String()
-							_ = ref
 							if len(img.RootFS.DiffIDs) == 0 {
 								isScratch = true
 								// schema1 images can't return diffIDs so double check :(

--- a/vendor/github.com/moby/buildkit/solver/internal/pipe/pipe.go
+++ b/vendor/github.com/moby/buildkit/solver/internal/pipe/pipe.go
@@ -89,7 +89,6 @@ func New(req Request) *Pipe {
 	roundTripCh := &channel{}
 	pw := &sender{
 		req:         req,
-		recvChannel: cancelCh,
 		sendChannel: roundTripCh,
 	}
 	pr := &receiver{
@@ -125,7 +124,6 @@ func New(req Request) *Pipe {
 type sender struct {
 	status      Status
 	req         Request
-	recvChannel *channel
 	sendChannel *channel
 	mu          sync.Mutex
 }

--- a/vendor/github.com/moby/buildkit/source/git/gitsource.go
+++ b/vendor/github.com/moby/buildkit/source/git/gitsource.go
@@ -37,17 +37,20 @@ type gitSource struct {
 	locker *locker.Locker
 }
 
+// Supported returns nil if the system supports Git source
+func Supported() error {
+	if err := exec.Command("git", "version").Run(); err != nil {
+		return errors.Wrap(err, "failed to find git binary")
+	}
+	return nil
+}
+
 func NewSource(opt Opt) (source.Source, error) {
 	gs := &gitSource{
 		md:     opt.MetadataStore,
 		cache:  opt.CacheAccessor,
 		locker: locker.New(),
 	}
-
-	if err := exec.Command("git", "version").Run(); err != nil {
-		return nil, errors.Wrap(err, "failed to find git binary")
-	}
-
 	return gs, nil
 }
 


### PR DESCRIPTION
Backport of https://github.com/moby/moby/pull/38339

brings in fix for setuid binaries moby/buildkit#745

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>
(cherry picked from commit 32f48058158cce7a6a1f8f0d1526d8224b369cbc)
