### PR TITLE
[18.09 backport] fixes display text in Multiple IDs found with provided prefix

### DIFF
--- a/pkg/truncindex/truncindex.go
+++ b/pkg/truncindex/truncindex.go
@@ -108,7 +108,7 @@ func (idx *TruncIndex) Get(s string) (string, error) {
 		if id != "" {
 			// we haven't found the ID if there are two or more IDs
 			id = ""
-			return ErrAmbiguousPrefix{prefix: string(prefix)}
+			return ErrAmbiguousPrefix{prefix: s}
 		}
 		id = string(prefix)
 		return nil


### PR DESCRIPTION
Backport of https://github.com/moby/moby/pull/37904 for 18.09
fixes https://github.com/moby/moby/issues/38345 for 18.09


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```Markdown
- Fix incorrect error message when finding a container by ID-prefix [moby/moby#37904](https://github.com/moby/moby/pull/37904)
```
