### PR TITLE
[18.06 backport] Swagger: fix definition of IPAM driver options

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1473,11 +1473,9 @@ definitions:
             type: "string"
       Options:
         description: "Driver-specific options, specified as a map."
-        type: "array"
-        items:
-          type: "object"
-          additionalProperties:
-            type: "string"
+        type: "object"
+        additionalProperties:
+          type: "string"
 
   NetworkContainer:
     type: "object"


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/38354 for 18.06
fixes https://github.com/moby/moby/issues/38353 for 18.06