### PR TITLE
[18.09 engine] registry: use len(via)!=0 instead of via!=nil

### DIFF
--- a/registry/registry.go
+++ b/registry/registry.go
@@ -145,7 +145,7 @@ func trustedLocation(req *http.Request) bool {
 // addRequiredHeadersToRedirectedRequests adds the necessary redirection headers
 // for redirected requests
 func addRequiredHeadersToRedirectedRequests(req *http.Request, via []*http.Request) error {
-	if via != nil && via[0] != nil {
+	if len(via) != 0 && via[0] != nil {
 		if trustedLocation(req) && trustedLocation(via[0]) {
 			req.Header = via[0].Header
 			return nil


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/38348 for 18.09
fixes https://github.com/moby/moby/issues/38347 for 18.09


```
git checkout -b 18.09_backport_fix_panic ce-engine/18.09    
git cherry-pick -s -S -x a5c185b99404ea3fbab47ff9d7ba143392566bc1
```

cherry-pick was clean; no conflicts



This avoids the corner case where `via` is not nil, but has a length of 0,
so the updated code does not panic in that situation.

