### PR TITLE
[18.09] Update containerd to aa5e000c963756778ab3ebd1a12c6

### DIFF
--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-CONTAINERD_COMMIT=9b32062dc1f5a7c2564315c269b5059754f12b9d # v1.2.1
+CONTAINERD_COMMIT=aa5e000c963756778ab3ebd1a12c67449c503a34 # v1.2.1+
 
 install_containerd() {
 	echo "Install containerd version $CONTAINERD_COMMIT"

--- a/vendor.conf
+++ b/vendor.conf
@@ -118,7 +118,7 @@ github.com/googleapis/gax-go v2.0.0
 google.golang.org/genproto 694d95ba50e67b2e363f3483057db5d4910c18f9
 
 # containerd
-github.com/containerd/containerd 9b32062dc1f5a7c2564315c269b5059754f12b9d # v1.2.1
+github.com/containerd/containerd aa5e000c963756778ab3ebd1a12c67449c503a34 # v1.2.1+
 github.com/containerd/fifo 3d5202aec260678c48179c56f40e6f38a095738c
 github.com/containerd/continuity bd77b46c8352f74eb12c85bdc01f4b90f69d66b4
 github.com/containerd/cgroups 5e610833b72089b37d0e615de9a92dfc043757c2


### PR DESCRIPTION
Backport https://github.com/moby/moby/pull/38376

```
$ git cherry-pick -s -x e5d9d72
[cont d161dfe1a3] Update containerd to aa5e000c963756778ab3ebd1a12c6
 Author: Michael Crosby <crosbymichael@gmail.com>
 Date: Fri Dec 14 15:41:41 2018 -0500
 4 files changed, 12 insertions(+), 2 deletions(-)
```

This includes a patch on top of containerd 1.2.1 to handle fifo
timeouts.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>
(cherry picked from commit e5d9d721626958a37dccfa0b234d9fc96d8c2bfb)
Signed-off-by: Andrew Hsu <andrewhsu@docker.com>