### PR TITLE
[18.09] Propagate context to exec delete

### DIFF
--- a/libcontainerd/client_daemon.go
+++ b/libcontainerd/client_daemon.go
@@ -384,7 +384,7 @@ func (c *client) Exec(ctx context.Context, containerID, processID string, spec *
 	defer close(stdinCloseSync)
 
 	if err = p.Start(ctx); err != nil {
-		p.Delete(context.Background())
+		p.Delete(ctx)
 		ctr.deleteProcess(processID)
 		return -1, wrapError(err)
 	}


### PR DESCRIPTION
Backport https://github.com/moby/moby/pull/38374

```
$ git cherry-pick -s -x 96e0ba1
[ctxt b6430ba413] Propagate context to exec delete
 Author: Michael Crosby <crosbymichael@gmail.com>
 Date: Fri Dec 14 11:56:23 2018 -0500
 1 file changed, 1 insertion(+), 1 deletion(-)
```

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>
(cherry picked from commit 96e0ba1afb228b48aa6e08a90cfc665083d24ccc)
Signed-off-by: Andrew Hsu <andrewhsu@docker.com>