### PR TITLE
[18.09] libcontainerd: prevent exec delete locking

### DIFF
--- a/libcontainerd/client_daemon.go
+++ b/libcontainerd/client_daemon.go
@@ -384,7 +384,7 @@ func (c *client) Exec(ctx context.Context, containerID, processID string, spec *
 	defer close(stdinCloseSync)
 
 	if err = p.Start(ctx); err != nil {
-		p.Delete(ctx)
+		p.Delete(context.Background())
 		ctr.deleteProcess(processID)
 		return -1, wrapError(err)
 	}

--- a/libcontainerd/client_daemon.go
+++ b/libcontainerd/client_daemon.go
@@ -29,7 +29,7 @@ import (
 	"github.com/containerd/typeurl"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/pkg/ioutils"
-	"github.com/opencontainers/image-spec/specs-go/v1"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -384,7 +384,12 @@ func (c *client) Exec(ctx context.Context, containerID, processID string, spec *
 	defer close(stdinCloseSync)
 
 	if err = p.Start(ctx); err != nil {
-		p.Delete(context.Background())
+		// use new context for cleanup because old one may be cancelled by user, but leave a timeout to make sure
+		// we are not waiting forever if containerd is unresponsive or to work around fifo cancelling issues in
+		// older containerd-shim
+		ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+		defer cancel()
+		p.Delete(ctx)
 		ctr.deleteProcess(processID)
 		return -1, wrapError(err)
 	}


### PR DESCRIPTION

Talked with @tonistiigi about https://github.com/moby/moby/pull/38374#issuecomment-447675200 and worked out an alternative approach for the 18.09 codeline.

This PR reverts #139. Instead, an alternative backport https://github.com/moby/moby/pull/38383 is brought in.

```
$ git revert -s b6430ba
$ git cherry-pick -s -x 332f134
[d 6646d08782] libcontainerd: prevent exec delete locking
 Author: Tonis Tiigi <tonistiigi@gmail.com>
 Date: Mon Dec 17 12:22:37 2018 +0200
 1 file changed, 7 insertions(+), 2 deletions(-)
```