### PR TITLE
[18.09] Bump Golang 1.10.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,10 +24,10 @@
 # the case. Therefore, you don't have to disable it anymore.
 #
 
-FROM golang:1.10.6 AS base
+FROM golang:1.10.7 AS base
 # FIXME(vdemeester) this is kept for other script depending on it to not fail right away
 # Remove this once the other scripts uses something else to detect the version
-ENV GO_VERSION 1.10.6
+ENV GO_VERSION 1.10.7
 # allow replacing httpredir or deb mirror
 ARG APT_MIRROR=deb.debian.org
 RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -1,5 +1,5 @@
 ## Step 1: Build tests
-FROM golang:1.10.6-alpine3.7 as builder
+FROM golang:1.10.7-alpine3.7 as builder
 
 RUN apk add --update \
     bash \

--- a/Dockerfile.simple
+++ b/Dockerfile.simple
@@ -42,7 +42,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 #            will need updating, to avoid errors. Ping #docker-maintainers on IRC
 #            with a heads-up.
 # IMPORTANT: When updating this please note that stdlib archive/tar pkg is vendored
-ENV GO_VERSION 1.10.6
+ENV GO_VERSION 1.10.7
 RUN curl -fsSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" \
 	| tar -xzC /usr/local
 ENV PATH /go/bin:/usr/local/go/bin:$PATH

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -161,7 +161,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 # Environment variable notes:
 #  - GO_VERSION must be consistent with 'Dockerfile' used by Linux.
 #  - FROM_DOCKERFILE is used for detection of building within a container.
-ENV GO_VERSION=1.10.6 `
+ENV GO_VERSION=1.10.7 `
     GIT_VERSION=2.11.1 `
     GOPATH=C:\go `
     FROM_DOCKERFILE=1


### PR DESCRIPTION
go1.10.7 (released 2018/12/14) includes a fix to a bug introduced in Go 1.10.6
that broke go get for import path patterns containing "...".

See the Go 1.10.7 milestone for details:
https://github.com/golang/go/issues?q=milestone%3AGo1.10.7+label%3ACherryPickApproved


