### PR TITLE
[18.09 backport] Skip kernel-memory tests on RHEL/CentOS daemons

### DIFF
--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -497,7 +497,7 @@ func (s *DockerSuite) TestRunWithInvalidCpuPeriod(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunWithKernelMemory(c *check.C) {
-	testRequires(c, kernelMemorySupport)
+	testRequires(c, DaemonIsLinux, kernelMemorySupport)
 
 	file := "/sys/fs/cgroup/memory/memory.kmem.limit_in_bytes"
 	cli.DockerCmd(c, "run", "--kernel-memory", "50M", "--name", "test1", "busybox", "cat", file).Assert(c, icmd.Expected{
@@ -510,7 +510,7 @@ func (s *DockerSuite) TestRunWithKernelMemory(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunWithInvalidKernelMemory(c *check.C) {
-	testRequires(c, kernelMemorySupport)
+	testRequires(c, DaemonIsLinux, kernelMemorySupport)
 
 	out, _, err := dockerCmdWithError("run", "--kernel-memory", "2M", "busybox", "true")
 	c.Assert(err, check.NotNil)

--- a/integration-cli/requirements_unix_test.go
+++ b/integration-cli/requirements_unix_test.go
@@ -38,6 +38,17 @@ func pidsLimit() bool {
 }
 
 func kernelMemorySupport() bool {
+	// TODO remove this once kmem support in RHEL kernels is fixed. See https://github.com/opencontainers/runc/pull/1921
+	daemonV, err := kernel.ParseRelease(testEnv.DaemonInfo.KernelVersion)
+	if err != nil {
+		return false
+	}
+	requiredV := kernel.VersionInfo{Kernel: 3, Major: 10}
+	if kernel.CompareKernelVersion(*daemonV, requiredV) < 1 {
+		// On Kernel 3.10 and under, don't consider kernel memory to be supported,
+		// even if the kernel (and thus the daemon) reports it as being supported
+		return false
+	}
 	return testEnv.DaemonInfo.KernelMemory
 }
 

--- a/pkg/parsers/kernel/kernel_unix_test.go
+++ b/pkg/parsers/kernel/kernel_unix_test.go
@@ -27,6 +27,7 @@ func TestParseRelease(t *testing.T) {
 	assertParseRelease(t, "3.4.54.longterm-1", &VersionInfo{Kernel: 3, Major: 4, Minor: 54, Flavor: ".longterm-1"}, 0)
 	assertParseRelease(t, "3.4.54.longterm-1", &VersionInfo{Kernel: 3, Major: 4, Minor: 54, Flavor: ".longterm-1"}, 0)
 	assertParseRelease(t, "3.8.0-19-generic", &VersionInfo{Kernel: 3, Major: 8, Minor: 0, Flavor: "-19-generic"}, 0)
+	assertParseRelease(t, "3.10.0-862.2.3.el7.x86_64", &VersionInfo{Kernel: 3, Major: 10, Minor: 0, Flavor: "-862.2.3.el7.x86_64"}, 0)
 	assertParseRelease(t, "3.12.8tag", &VersionInfo{Kernel: 3, Major: 12, Minor: 8, Flavor: "tag"}, 0)
 	assertParseRelease(t, "3.12-1-amd64", &VersionInfo{Kernel: 3, Major: 12, Minor: 0, Flavor: "-1-amd64"}, 0)
 	assertParseRelease(t, "3.8.0", &VersionInfo{Kernel: 4, Major: 8, Minor: 0}, -1)


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/38493 for 18.09; cherry-pick was clean


RHEL/CentOS 3.10 kernels report that kernel-memory accounting is supported,
but it actually does not work.

Runc (when compiled for those kernels) will be compiled without kernel-memory
support, so even though the daemon may be reporting that it's supported,
it actually is not.

This cause tests to fail when testing against a daemon that's using a runc
version without kmem support.

For now, skip these tests based on the kernel version reported by the daemon.

This should fix failures such as:

```
FAIL: /go/src/github.com/docker/docker/integration-cli/docker_cli_run_unix_test.go:499: DockerSuite.TestRunWithKernelMemory

assertion failed:
Command:  /usr/bin/docker run --kernel-memory 50M --name test1 busybox cat /sys/fs/cgroup/memory/memory.kmem.limit_in_bytes
ExitCode: 0
Error:    <nil>
Stdout:   9223372036854771712

Stderr:   WARNING: You specified a kernel memory limit on a kernel older than 4.0. Kernel memory limits are experimental on older kernels, it won't work as expected and can cause your system to be unstable.

Failures:
Expected stdout to contain "52428800"

FAIL: /go/src/github.com/docker/docker/integration-cli/docker_cli_update_unix_test.go:125: DockerSuite.TestUpdateKernelMemory

/go/src/github.com/docker/docker/integration-cli/docker_cli_update_unix_test.go:136:
    ...open /go/src/github.com/docker/docker/integration-cli/docker_cli_update_unix_test.go: no such file or directory
... obtained string = "9223372036854771712"
... expected string = "104857600"

----------------------------------------------------------------------
FAIL: /go/src/github.com/docker/docker/integration-cli/docker_cli_update_unix_test.go:139: DockerSuite.TestUpdateKernelMemoryUninitialized

/go/src/github.com/docker/docker/integration-cli/docker_cli_update_unix_test.go:149:
    ...open /go/src/github.com/docker/docker/integration-cli/docker_cli_update_unix_test.go: no such file or directory
... value = nil
```

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>
(cherry picked from commit 1e1156cf67233cf8eaee2da9c17465ff0d9c2aa0)
Signed-off-by: Sebastiaan van Stijn <github@gone.nl>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

