### PR TITLE
[18.09] backport #38573 "bump up runc"

### DIFF
--- a/hack/dockerfile/install/runc.installer
+++ b/hack/dockerfile/install/runc.installer
@@ -4,7 +4,7 @@
 # The version of runc should match the version that is used by the containerd
 # version that is used. If you need to update runc, open a pull request in
 # the containerd project first, and update both after that is merged.
-RUNC_COMMIT=96ec2177ae841256168fcf76954f7177af9446eb
+RUNC_COMMIT=12f6a991201fdb8f82579582d5e00e28fba06d0a
 
 install_runc() {
 	# If using RHEL7 kernels (3.10.0 el7), disable kmem accounting/limiting

--- a/vendor.conf
+++ b/vendor.conf
@@ -79,7 +79,7 @@ google.golang.org/grpc v1.12.0
 # the containerd project first, and update both after that is merged.
 # This commit does not need to match RUNC_COMMIT as it is used for helper
 # packages but should be newer or equal.
-github.com/opencontainers/runc 96ec2177ae841256168fcf76954f7177af9446eb
+github.com/opencontainers/runc 12f6a991201fdb8f82579582d5e00e28fba06d0a
 github.com/opencontainers/runtime-spec 5684b8af48c1ac3b1451fa499724e30e3c20a294 # v1.0.1-49-g5684b8a
 github.com/opencontainers/image-spec v1.0.1
 github.com/seccomp/libseccomp-golang 32f571b70023028bd57d9288c20efbcb237f3ce0

--- a/vendor/github.com/opencontainers/runc/libcontainer/cgroups/utils.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/cgroups/utils.go
@@ -463,7 +463,7 @@ func WriteCgroupProc(dir string, pid int) error {
 		return fmt.Errorf("no such directory for %s", CgroupProcesses)
 	}
 
-	// Dont attach any pid to the cgroup if -1 is specified as a pid
+	// Don't attach any pid to the cgroup if -1 is specified as a pid
 	if pid != -1 {
 		if err := ioutil.WriteFile(filepath.Join(dir, CgroupProcesses), []byte(strconv.Itoa(pid)), 0700); err != nil {
 			return fmt.Errorf("failed to write %v to %v: %v", pid, CgroupProcesses, err)


### PR DESCRIPTION
https://github.com/moby/moby/pull/38573

--- 

Changes: https://github.com/opencontainers/runc/compare/96ec2177ae841256168fcf76954f7177af9446eb...12f6a991201fdb8f82579582d5e00e28fba06d0a

Including critical security fix for `runc run --no-pivot` (`DOCKER_RAMDISK=1`): https://github.com/opencontainers/runc/pull/1962

(NOTE: the vuln is attackable only when `DOCKER_RAMDISK=1` is set && seccomp is disabled)


Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>
(cherry picked from commit 1ee33f41429769de28b223c285fdfe570e572533)
