### PR TITLE
[18.06] backport #38573 "bump up runc" 

### DIFF
--- a/hack/dockerfile/install/runc.installer
+++ b/hack/dockerfile/install/runc.installer
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # When updating RUNC_COMMIT, also update runc in vendor.conf accordingly
-RUNC_COMMIT=69663f0bd4b60df09991c08812a60108003fa340
+RUNC_COMMIT=12f6a991201fdb8f82579582d5e00e28fba06d0a
 
 install_runc() {
 	# Do not build with ambient capabilities support


### PR DESCRIPTION
https://github.com/moby/moby/pull/38573

---


Changes: https://github.com/opencontainers/runc/compare/69663f0bd4b60df09991c08812a60108003fa340...12f6a991201fdb8f82579582d5e00e28fba06d0a

Including critical security fix for `runc run --no-pivot` (`DOCKER_RAMDISK=1`): https://github.com/opencontainers/runc/pull/1962

(NOTE: the vuln is attackable only when `DOCKER_RAMDISK=1` is set && seccomp is disabled)

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>
