### PR TITLE
[18.09 backport] pkg/archive: fix TestTarUntarWithXattr failure on recent kernel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -186,6 +186,7 @@ RUN apt-get update && apt-get install -y \
 	btrfs-tools \
 	iptables \
 	jq \
+	libcap2-bin \
 	libdevmapper-dev \
 	libudev-dev \
 	libsystemd-dev \

--- a/pkg/archive/archive_unix_test.go
+++ b/pkg/archive/archive_unix_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"syscall"
@@ -222,6 +223,13 @@ func TestTarWithBlockCharFifo(t *testing.T) {
 // TestTarUntarWithXattr is Unix as Lsetxattr is not supported on Windows
 func TestTarUntarWithXattr(t *testing.T) {
 	skip.If(t, os.Getuid() != 0, "skipping test that requires root")
+	if _, err := exec.LookPath("setcap"); err != nil {
+		t.Skip("setcap not installed")
+	}
+	if _, err := exec.LookPath("getcap"); err != nil {
+		t.Skip("getcap not installed")
+	}
+
 	origin, err := ioutil.TempDir("", "docker-test-untar-origin")
 	assert.NilError(t, err)
 	defer os.RemoveAll(origin)
@@ -232,8 +240,9 @@ func TestTarUntarWithXattr(t *testing.T) {
 	assert.NilError(t, err)
 	err = ioutil.WriteFile(filepath.Join(origin, "3"), []byte("will be ignored"), 0700)
 	assert.NilError(t, err)
-	err = system.Lsetxattr(filepath.Join(origin, "2"), "security.capability", []byte{0x00}, 0)
-	assert.NilError(t, err)
+	// there is no known Go implementation of setcap/getcap with support for v3 file capability
+	out, err := exec.Command("setcap", "cap_block_suspend+ep", filepath.Join(origin, "2")).CombinedOutput()
+	assert.NilError(t, err, string(out))
 
 	for _, c := range []Compression{
 		Uncompressed,
@@ -251,10 +260,9 @@ func TestTarUntarWithXattr(t *testing.T) {
 		if len(changes) != 1 || changes[0].Path != "/3" {
 			t.Fatalf("Unexpected differences after tarUntar: %v", changes)
 		}
-		capability, _ := system.Lgetxattr(filepath.Join(origin, "2"), "security.capability")
-		if capability == nil && capability[0] != 0x00 {
-			t.Fatalf("Untar should have kept the 'security.capability' xattr.")
-		}
+		out, err := exec.Command("getcap", filepath.Join(origin, "2")).CombinedOutput()
+		assert.NilError(t, err, string(out))
+		assert.Check(t, is.Contains(string(out), "= cap_block_suspend+ep"), "untar should have kept the 'security.capability' xattr")
 	}
 }
 


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/38292 for 18.09; cherry-pick was clean; no conflicts


Recent kernel has strict check for security.capability value.
Fix #38289

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>
(cherry picked from commit 9ddd6e47a90ac056d242969ff72bf75a43cc0004)
Signed-off-by: Sebastiaan van Stijn <github@gone.nl>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

