### PR TITLE
[18.09 backport] Fix: plugin-tests discarding current environment

### DIFF
--- a/integration/plugin/logging/helpers_test.go
+++ b/integration/plugin/logging/helpers_test.go
@@ -31,7 +31,7 @@ func ensurePlugin(t *testing.T, name string) string {
 	}
 
 	cmd := exec.Command(goBin, "build", "-o", installPath, "./"+filepath.Join("cmd", name))
-	cmd.Env = append(cmd.Env, "CGO_ENABLED=0")
+	cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatal(errors.Wrapf(err, "error building basic plugin bin: %s", string(out)))
 	}

--- a/integration/plugin/volumes/helpers_test.go
+++ b/integration/plugin/volumes/helpers_test.go
@@ -37,7 +37,7 @@ func ensurePlugin(t *testing.T, name string) string {
 	}
 
 	cmd := exec.Command(goBin, "build", "-o", installPath, "./"+filepath.Join("cmd", name))
-	cmd.Env = append(cmd.Env, "CGO_ENABLED=0")
+	cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatal(errors.Wrapf(err, "error building basic plugin bin: %s", string(out)))
 	}

--- a/internal/test/fixtures/plugin/plugin.go
+++ b/internal/test/fixtures/plugin/plugin.go
@@ -208,7 +208,7 @@ func ensureBasicPluginBin() (string, error) {
 	installPath := filepath.Join(os.Getenv("GOPATH"), "bin", name)
 	sourcePath := filepath.Join("github.com", "docker", "docker", "internal", "test", "fixtures", "plugin", "basic")
 	cmd := exec.Command(goBin, "build", "-o", installPath, sourcePath)
-	cmd.Env = append(cmd.Env, "GOPATH="+os.Getenv("GOPATH"), "CGO_ENABLED=0")
+	cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return "", errors.Wrapf(err, "error building basic plugin bin: %s", string(out))
 	}


### PR DESCRIPTION
Thought I'd backport this one, as it caused some head-scratching when working on https://github.com/moby/moby/pull/38404#issuecomment-453307983

backport of https://github.com/moby/moby/pull/38543 for 18.09. Cherry-pick was clean; no conflicts.


By default, exec uses the environment of the current process, however,
if `exec.Env` is not `nil`, the environment is discarded:

https://github.com/golang/go/blob/e73f4894949c4ced611881329ff8f37805152585/src/os/exec/exec.go#L57-L60

> If Env is nil, the new process uses the current process's environment.

When adding a new environment variable, prepend the current environment,
to make sure it is not discarded.

