### PR TITLE
[18.09 backport] Fix nil pointer derefence on failure to connect to containerd

### DIFF
--- a/libcontainerd/supervisor/remote_daemon.go
+++ b/libcontainerd/supervisor/remote_daemon.go
@@ -311,6 +311,8 @@ func (r *remote) monitorDaemon(ctx context.Context) {
 				delay = time.After(time.Duration(transientFailureCount) * 200 * time.Millisecond)
 				continue
 			}
+			client.Close()
+			client = nil
 		}
 
 		if system.IsProcessAlive(r.daemonPid) {
@@ -318,8 +320,6 @@ func (r *remote) monitorDaemon(ctx context.Context) {
 			r.killDaemon()
 		}
 
-		client.Close()
-		client = nil
 		r.daemonPid = -1
 		delay = nil
 		transientFailureCount = 0


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/38653 for 18.09

fixes https://github.com/moby/moby/issues/38636
addresses https://github.com/docker/for-linux/issues/517#issuecomment-466358473