### PR TITLE
[18.09] bump swarmkit to c66ed60822d3fc3bf6e17a505ee79014f449ef05 (bump 18.09)

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -130,7 +130,7 @@ github.com/containerd/ttrpc 2a805f71863501300ae1976d29f0454ae003e85a
 github.com/gogo/googleapis 08a7655d27152912db7aaf4f983275eaf8d128ef
 
 # cluster
-github.com/docker/swarmkit 6186e40fb04a7681e25a9101dbc7418c37ef0c8b # bump_v18.09 branch
+github.com/docker/swarmkit c66ed60822d3fc3bf6e17a505ee79014f449ef05 # bump_v18.09 branch
 github.com/gogo/protobuf v1.0.0
 github.com/cloudflare/cfssl 1.3.2
 github.com/fernet/fernet-go 1b2437bc582b3cfbb341ee5a29f8ef5b42912ff2

--- a/vendor/github.com/docker/swarmkit/manager/controlapi/service.go
+++ b/vendor/github.com/docker/swarmkit/manager/controlapi/service.go
@@ -680,13 +680,17 @@ func (s *Server) CreateService(ctx context.Context, request *api.CreateServiceRe
 
 		return store.CreateService(tx, service)
 	})
-	if err != nil {
+	switch err {
+	case store.ErrNameConflict:
+		// Enhance the name-confict error to include the service name. The original
+		// `ErrNameConflict` error-message is included for backward-compatibility
+		// with older consumers of the API performing string-matching.
+		return nil, status.Errorf(codes.AlreadyExists, "%s: service %s already exists", err.Error(), request.Spec.Annotations.Name)
+	case nil:
+		return &api.CreateServiceResponse{Service: service}, nil
+	default:
 		return nil, err
 	}
-
-	return &api.CreateServiceResponse{
-		Service: service,
-	}, nil
 }
 
 // GetService returns a Service given a ServiceID.
@@ -896,7 +900,12 @@ func (s *Server) ListServices(ctx context.Context, request *api.ListServicesRequ
 		}
 	})
 	if err != nil {
-		return nil, err
+		switch err {
+		case store.ErrInvalidFindBy:
+			return nil, status.Errorf(codes.InvalidArgument, err.Error())
+		default:
+			return nil, err
+		}
 	}
 
 	if request.Filters != nil {


### PR DESCRIPTION
full diff: https://github.com/docker/swarmkit/compare/6186e40fb04a7681e25a9101dbc7418c37ef0c8b...c66ed60822d3fc3bf6e17a505ee79014f449ef05

Relevant changes:

- https://github.com/docker/swarmkit/pull/2826 [18.09 backport] use a custom grpc dialer when managers are joining (backport of https://github.com/docker/swarmkit/pull/2802, which is a follow-up to https://github.com/docker/swarmkit/pull/2419)
- https://github.com/docker/swarmkit/pull/2801 [18.09 backport] Include old error-message for backward compatibility (backport of https://github.com/docker/swarmkit/pull/2797)
- https://github.com/docker/swarmkit/pull/2788 [18.09 backport] Return correct error-codes on conflicting names (backport of https://github.com/docker/swarmkit/pull/2779)