### PR TITLE
[18.09 backport] builder-next: fix squash

### DIFF
--- a/api/server/backend/build/backend.go
+++ b/api/server/backend/build/backend.go
@@ -82,8 +82,8 @@ func (b *Backend) Build(ctx context.Context, config backend.BuildConfig) (string
 	if !useBuildKit {
 		stdout := config.ProgressWriter.StdoutFormatter
 		fmt.Fprintf(stdout, "Successfully built %s\n", stringid.TruncateID(imageID))
-		err = tagger.TagImages(image.ID(imageID))
 	}
+	err = tagger.TagImages(image.ID(imageID))
 	return imageID, err
 }
 


### PR DESCRIPTION
Tagger was not called for BuildKit-mode.

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>
(cherry picked from commit 7fc0f820ea1e9036a1466ee8ef7a7395b792623f)
Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>

---

https://github.com/moby/moby/pull/38902