### PR TITLE
[18.09 backport] Use original process spec for execs

### DIFF
--- a/integration/container/exec_test.go
+++ b/integration/container/exec_test.go
@@ -118,3 +118,18 @@ func TestExec(t *testing.T) {
 	assert.Assert(t, is.Contains(out, "PWD=/tmp"), "exec command not running in expected /tmp working directory")
 	assert.Assert(t, is.Contains(out, "FOO=BAR"), "exec command not running with expected environment variable FOO")
 }
+
+func TestExecUser(t *testing.T) {
+	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.39"), "broken in earlier versions")
+	skip.If(t, testEnv.OSType == "windows", "FIXME. Probably needs to wait for container to be in running state.")
+	defer setupTest(t)()
+	ctx := context.Background()
+	client := testEnv.APIClient()
+
+	cID := container.Run(t, ctx, client, container.WithTty(true), container.WithUser("1:1"))
+
+	result, err := container.Exec(ctx, client, cID, []string{"id"})
+	assert.NilError(t, err)
+
+	assert.Assert(t, is.Contains(result.Stdout(), "uid=1(daemon) gid=1(daemon)"), "exec command not running as uid/gid 1")
+}

--- a/integration/internal/container/ops.go
+++ b/integration/internal/container/ops.go
@@ -134,3 +134,10 @@ func WithAutoRemove(c *TestContainerConfig) {
 	}
 	c.HostConfig.AutoRemove = true
 }
+
+// WithUser sets the user
+func WithUser(user string) func(c *TestContainerConfig) {
+	return func(c *TestContainerConfig) {
+		c.Config.User = user
+	}
+}


### PR DESCRIPTION
Backport of https://github.com/moby/moby/pull/38871 for 18.09
fixes https://github.com/moby/moby/issues/38865 for 18.09