### PR TITLE
[do not merge][19.03 backport] Use original process spec for execs

### DIFF
--- a/integration/internal/container/ops.go
+++ b/integration/internal/container/ops.go
@@ -153,3 +153,10 @@ func WithRestartPolicy(policy string) func(c *TestContainerConfig) {
 		c.HostConfig.RestartPolicy.Name = policy
 	}
 }
+
+// WithUser sets the user
+func WithUser(user string) func(c *TestContainerConfig) {
+	return func(c *TestContainerConfig) {
+		c.Config.User = user
+	}
+}


### PR DESCRIPTION
Backport of https://github.com/moby/moby/pull/38871 for 19.03
fixes https://github.com/moby/moby/issues/38865 for 19.03