### PR TITLE
[18.09 backport] Fix: network=host using wrong resolv.conf with systemd-resolved

### DIFF
--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -375,10 +375,10 @@ func (daemon *Daemon) setupPathsAndSandboxOptions(container *container.Container
 	if container.HostConfig.NetworkMode.IsHost() {
 		// Point to the host files, so that will be copied into the container running in host mode
 		*sboxOptions = append(*sboxOptions, libnetwork.OptionOriginHostsPath("/etc/hosts"))
-		*sboxOptions = append(*sboxOptions, libnetwork.OptionOriginResolvConfPath("/etc/resolv.conf"))
-	} else {
-		*sboxOptions = append(*sboxOptions, libnetwork.OptionOriginResolvConfPath(daemon.configStore.GetResolvConf()))
 	}
+
+	// Copy the host's resolv.conf for the container (/etc/resolv.conf or /run/systemd/resolve/resolv.conf)
+	*sboxOptions = append(*sboxOptions, libnetwork.OptionOriginResolvConfPath(daemon.configStore.GetResolvConf()))
 
 	container.HostsPath, err = container.GetRootResourcePath("hosts")
 	if err != nil {


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/38579 for 18.09


When running a container in the host's network namespace, the container
gets a copy of the host's resolv.conf (copied to `/etc/resolv.conf` inside
the container).

The current code always used the default (`/etc/resolv.conf`) path on the
host, irregardless if `systemd-resolved` was used or not.

This patch uses the correct file if `systemd-resolved` was detected
to be running.


