### PR TITLE
[do not merge][19.03 backport] bump swarmkit 18e7e58ea1a5ec016625a636d0d52500eea123bc

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -131,7 +131,7 @@ github.com/containerd/ttrpc f02858b1457c5ca3aaec3a0803eb0d59f96e41d6
 github.com/gogo/googleapis 08a7655d27152912db7aaf4f983275eaf8d128ef
 
 # cluster
-github.com/docker/swarmkit 415dc72789e2b733ea884f09188c286ca187d8ec
+github.com/docker/swarmkit 18e7e58ea1a5ec016625a636d0d52500eea123bc
 github.com/gogo/protobuf v1.2.0
 github.com/cloudflare/cfssl 1.3.2
 github.com/fernet/fernet-go 1b2437bc582b3cfbb341ee5a29f8ef5b42912ff2


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/38937 for 19.03

full diff: https://github.com/docker/swarmkit/compare/415dc72789e2b733ea884f09188c286ca187d8ec...18e7e58ea1a5ec016625a636d0d52500eea123bc

changes included:

- https://github.com/docker/swarmkit/pull/2806 Fix leaking task resources when nodes are deleted
- https://github.com/docker/swarmkit/pull/2817 Add validation to CredentialSpec configs
