### PR TITLE
[18.09 backport] update containerd/cgroups 4994991857f9b0ae8dc439551e8bebdbb4bf66c1

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -121,7 +121,7 @@ google.golang.org/genproto 694d95ba50e67b2e363f3483057db5d4910c18f9
 github.com/containerd/containerd 9754871865f7fe2f4e74d43e2fc7ccd237edcbce # v1.2.2
 github.com/containerd/fifo 3d5202aec260678c48179c56f40e6f38a095738c
 github.com/containerd/continuity 004b46473808b3e7a4a3049c20e4376c91eb966d
-github.com/containerd/cgroups dbea6f2bd41658b84b00417ceefa416b979cbf10
+github.com/containerd/cgroups 4994991857f9b0ae8dc439551e8bebdbb4bf66c1
 github.com/containerd/console c12b1e7919c14469339a5d38f2f8ed9b64a9de23
 github.com/containerd/cri 0d5cabd006cb5319dc965046067b8432d9fa5ef8 # release/1.2 branch
 github.com/containerd/go-runc 5a6d9f37cfa36b15efba46dc7ea349fa9b7143c3

--- a/vendor/github.com/containerd/cgroups/cgroup.go
+++ b/vendor/github.com/containerd/cgroups/cgroup.go
@@ -105,6 +105,10 @@ func Load(hierarchy Hierarchy, path Path, opts ...InitOpts) (Cgroup, error) {
 		}
 		activeSubsystems = append(activeSubsystems, s)
 	}
+	// if we do not have any active systems then the cgroup is deleted
+	if len(activeSubsystems) == 0 {
+		return nil, ErrCgroupDeleted
+	}
 	return &cgroup{
 		path:       path,
 		subsystems: activeSubsystems,


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/38965 for 18.09

full diff: https://github.com/containerd/cgroups/compare/dbea6f2bd41658b84b00417ceefa416b979cbf10...4994991857f9b0ae8dc439551e8bebdbb4bf66c1

brings in https://github.com/containerd/cgroups/pull/79 Return ErrCgroupDeleted when no subsystems
relates to https://github.com/containerd/containerd/issues/3133 Custom cgroup path does not work in containerd 1.2.5

