### PR TITLE
[18.09] bump buildkit ed4da8b4a9661f278ae8433056ca37d0727c408b (docker-18.09 branch)

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -26,7 +26,7 @@ github.com/imdario/mergo v0.3.6
 golang.org/x/sync 1d60e4601c6fd243af51cc01ddf169918a5407ca
 
 # buildkit
-github.com/moby/buildkit d9f75920678e35090025bb89344c5370e2efc8e7
+github.com/moby/buildkit ed4da8b4a9661f278ae8433056ca37d0727c408b # docker-18.09 branch
 github.com/tonistiigi/fsutil 2862f6bc5ac9b97124e552a5c108230b38a1b0ca
 github.com/grpc-ecosystem/grpc-opentracing 8e809c8a86450a29b90dcc9efbf062d0fe6d9746
 github.com/opentracing/opentracing-go 1361b9cd60be79c4c3a7fa9841b3c132e40066a7

--- a/vendor/github.com/moby/buildkit/solver/llbsolver/ops/exec.go
+++ b/vendor/github.com/moby/buildkit/solver/llbsolver/ops/exec.go
@@ -151,7 +151,7 @@ func dedupePaths(inp []string) []string {
 	for p1 := range old {
 		var skip bool
 		for p2 := range old {
-			if p1 != p2 && strings.HasPrefix(p1, p2) {
+			if p1 != p2 && strings.HasPrefix(p1, p2+"/") {
 				skip = true
 				break
 			}


### PR DESCRIPTION
brings in moby/buildkit#911 [docker-18.09] llbsolver: fix selectors dedupe
(backport of https://github.com/moby/buildkit/pull/858)

fixes https://github.com/moby/moby/issues/38964

