### PR TITLE
[18.09 backport] Vendor Libnetwork c902989

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -37,7 +37,7 @@ github.com/mitchellh/hashstructure 2bca23e0e452137f789efbc8610126fd8b94f73b
 #get libnetwork packages
 
 # When updating, also update LIBNETWORK_COMMIT in hack/dockerfile/install/proxy accordingly
-github.com/docker/libnetwork 4725f2163fb214a6312f3beae5991f838ec36326 # bump_18.09 branch
+github.com/docker/libnetwork c9029898e32f7c89bbb81511fbb721df252ce61a # bump_18.09 branch
 github.com/docker/go-events 9461782956ad83b30282bf90e31fa6a70c255ba9
 github.com/armon/go-radix e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec

--- a/vendor/github.com/docker/libnetwork/drivers/windows/overlay/joinleave_windows.go
+++ b/vendor/github.com/docker/libnetwork/drivers/windows/overlay/joinleave_windows.go
@@ -95,7 +95,10 @@ func (d *driver) EventNotify(etype driverapi.EventType, nid, tableName, key stri
 		return
 	}
 
-	d.peerAdd(nid, eid, addr.IP, addr.Mask, mac, vtep, true)
+	err = d.peerAdd(nid, eid, addr.IP, addr.Mask, mac, vtep, true)
+	if err != nil {
+		logrus.Errorf("peerAdd failed (%v) for ip %s with mac %s", err, addr.IP.String(), mac.String())
+	}
 }
 
 func (d *driver) DecodeTableEntry(tablename string, key string, value []byte) (string, map[string]string) {

--- a/vendor/github.com/docker/libnetwork/drivers/windows/overlay/peerdb_windows.go
+++ b/vendor/github.com/docker/libnetwork/drivers/windows/overlay/peerdb_windows.go
@@ -67,8 +67,7 @@ func (d *driver) peerAdd(nid, eid string, peerIP net.IP, peerIPMask net.IPMask,
 		}
 
 		n.removeEndpointWithAddress(addr)
-
-		hnsresponse, err := hcsshim.HNSEndpointRequest("POST", "", string(configurationb))
+		hnsresponse, err := endpointRequest("POST", "", string(configurationb))
 		if err != nil {
 			return err
 		}
@@ -108,7 +107,7 @@ func (d *driver) peerDelete(nid, eid string, peerIP net.IP, peerIPMask net.IPMas
 	}
 
 	if updateDb {
-		_, err := hcsshim.HNSEndpointRequest("DELETE", ep.profileID, "")
+		_, err := endpointRequest("DELETE", ep.profileID, "")
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION

This commit brings in https://github.com/docker/libnetwork/pull/2356 and https://github.com/docker/libnetwork/pull/2357. Adds a workaround for a WS2016 HNS race issue by serializing the L2 Table programming across networks.

Signed-off-by: Madhu Venugopal <madhu@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

