### PR TITLE
[WIP][19.03] Vendor Libnetwork 48f8463 to 19.03

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -39,7 +39,7 @@ github.com/gofrs/flock 7f43ea2e6a643ad441fc12d0ecc0d3388b300c53 # v0.7.0
 #get libnetwork packages
 
 # When updating, also update LIBNETWORK_COMMIT in hack/dockerfile/install/proxy.installer accordingly
-github.com/docker/libnetwork ebcade70ad1059b070d0040d798ecca359bc5fed
+github.com/docker/libnetwork 48f846327bbe6a0dce0c556e8dc9f5bb939d5c16
 github.com/docker/go-events 9461782956ad83b30282bf90e31fa6a70c255ba9
 github.com/armon/go-radix e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec

--- a/vendor/github.com/docker/libnetwork/drivers/windows/overlay/joinleave_windows.go
+++ b/vendor/github.com/docker/libnetwork/drivers/windows/overlay/joinleave_windows.go
@@ -95,7 +95,10 @@ func (d *driver) EventNotify(etype driverapi.EventType, nid, tableName, key stri
 		return
 	}
 
-	d.peerAdd(nid, eid, addr.IP, addr.Mask, mac, vtep, true)
+	err = d.peerAdd(nid, eid, addr.IP, addr.Mask, mac, vtep, true)
+	if err != nil {
+		logrus.Errorf("peerAdd failed (%v) for ip %s with mac %s", err, addr.IP.String(), mac.String())
+	}
 }
 
 func (d *driver) DecodeTableEntry(tablename string, key string, value []byte) (string, map[string]string) {

--- a/vendor/github.com/docker/libnetwork/drivers/windows/overlay/peerdb_windows.go
+++ b/vendor/github.com/docker/libnetwork/drivers/windows/overlay/peerdb_windows.go
@@ -67,8 +67,7 @@ func (d *driver) peerAdd(nid, eid string, peerIP net.IP, peerIPMask net.IPMask,
 		}
 
 		n.removeEndpointWithAddress(addr)
-
-		hnsresponse, err := hcsshim.HNSEndpointRequest("POST", "", string(configurationb))
+		hnsresponse, err := endpointRequest("POST", "", string(configurationb))
 		if err != nil {
 			return err
 		}
@@ -108,7 +107,7 @@ func (d *driver) peerDelete(nid, eid string, peerIP net.IP, peerIPMask net.IPMas
 	}
 
 	if updateDb {
-		_, err := hcsshim.HNSEndpointRequest("DELETE", ep.profileID, "")
+		_, err := endpointRequest("DELETE", ep.profileID, "")
 		if err != nil {
 			return err
 		}

--- a/vendor/github.com/docker/libnetwork/netutils/utils_linux.go
+++ b/vendor/github.com/docker/libnetwork/netutils/utils_linux.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/libnetwork/osl"
 	"github.com/docker/libnetwork/resolvconf"
 	"github.com/docker/libnetwork/types"
+	"github.com/pkg/errors"
 	"github.com/vishvananda/netlink"
 )
 
@@ -97,8 +98,7 @@ func ElectInterfaceAddresses(name string) ([]*net.IPNet, []*net.IPNet, error) {
 		// Choose from predefined local scope networks
 		v4Net, err := FindAvailableNetwork(ipamutils.PredefinedLocalScopeDefaultNetworks)
 		if err != nil {
-			return nil, nil, fmt.Errorf("%s, PredefinedLocalScopeDefaultNetworks List: %+v",
-				err.Error(),
+			return nil, nil, errors.Wrapf(err, "PredefinedLocalScopeDefaultNetworks List: %+v",
 				ipamutils.PredefinedLocalScopeDefaultNetworks)
 		}
 		v4Nets = append(v4Nets, v4Net)


### PR DESCRIPTION
This commit brings in docker/libnetwork#2356 and docker/libnetwork#2357. Adds a workaround for a WS2016 HNS race issue by serializing the L2 Table programming across networks.

Signed-off-by: Madhu Venugopal <madhu@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

