### PR TITLE
[18.09 backport] Adds PartialLogMetadata to encode protobuf for logger plugins

### DIFF
--- a/daemon/logger/adapter.go
+++ b/daemon/logger/adapter.go
@@ -39,6 +39,13 @@ func (a *pluginAdapter) Log(msg *Message) error {
 	a.buf.TimeNano = msg.Timestamp.UnixNano()
 	a.buf.Partial = msg.PLogMetaData != nil
 	a.buf.Source = msg.Source
+	if msg.PLogMetaData != nil {
+		a.buf.PartialLogMetadata = &logdriver.PartialLogEntryMetadata{
+			Id:      msg.PLogMetaData.ID,
+			Last:    msg.PLogMetaData.Last,
+			Ordinal: int32(msg.PLogMetaData.Ordinal),
+		}
+	}
 
 	err := a.enc.Encode(&a.buf)
 	a.buf.Reset()


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/39038 for 18.09