### PR TITLE
[18.09 backport] Improve 'no matching manifest' error

### DIFF
--- a/distribution/pull_v2.go
+++ b/distribution/pull_v2.go
@@ -756,7 +756,7 @@ func (p *v2Puller) pullManifestList(ctx context.Context, ref reference.Named, mf
 	manifestMatches := filterManifests(mfstList.Manifests, platform)
 
 	if len(manifestMatches) == 0 {
-		errMsg := fmt.Sprintf("no matching manifest for %s in the manifest list entries", platforms.Format(platform))
+		errMsg := fmt.Sprintf("no matching manifest for %s in the manifest list entries", formatPlatform(platform))
 		logrus.Debugf(errMsg)
 		return "", "", errors.New(errMsg)
 	}

--- a/distribution/pull_v2_test.go
+++ b/distribution/pull_v2_test.go
@@ -2,8 +2,10 @@ package distribution // import "github.com/docker/docker/distribution"
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"reflect"
+	"regexp"
 	"runtime"
 	"strings"
 	"testing"
@@ -11,6 +13,7 @@ import (
 	"github.com/docker/distribution/manifest/schema1"
 	"github.com/docker/distribution/reference"
 	"github.com/opencontainers/go-digest"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
 )
@@ -180,5 +183,25 @@ func TestValidateManifest(t *testing.T) {
 	verifiedManifest, err = verifySchema1Manifest(&badSignedManifest, expectedDigest)
 	if err == nil || !strings.HasPrefix(err.Error(), "image verification failed for digest") {
 		t.Fatal("expected validateManifest to fail with digest error")
+	}
+}
+
+func TestFormatPlatform(t *testing.T) {
+	var platform specs.Platform
+	var result = formatPlatform(platform)
+	if strings.HasPrefix(result, "unknown") {
+		t.Fatal("expected formatPlatform to show a known platform")
+	}
+	if !strings.HasPrefix(result, runtime.GOOS) {
+		t.Fatal("expected formatPlatform to show the current platform")
+	}
+	if runtime.GOOS == "windows" {
+		if !strings.HasPrefix(result, "windows") {
+			t.Fatal("expected formatPlatform to show windows platform")
+		}
+		matches, _ := regexp.MatchString("windows.* [0-9]", result)
+		if !matches {
+			t.Fatal(fmt.Sprintf("expected formatPlatform to show windows platform with a version, but got '%s'", result))
+		}
 	}
 }

--- a/distribution/pull_v2_unix.go
+++ b/distribution/pull_v2_unix.go
@@ -58,3 +58,10 @@ func withDefault(p specs.Platform) specs.Platform {
 	}
 	return p
 }
+
+func formatPlatform(platform specs.Platform) string {
+	if platform.OS == "" {
+		platform = platforms.DefaultSpec()
+	}
+	return platforms.Format(platform)
+}

--- a/distribution/pull_v2_windows.go
+++ b/distribution/pull_v2_windows.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/containerd/containerd/platforms"
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/manifest/manifestlist"
 	"github.com/docker/distribution/manifest/schema2"
@@ -135,4 +136,11 @@ func checkImageCompatibility(imageOS, imageOSVersion string) error {
 		}
 	}
 	return nil
+}
+
+func formatPlatform(platform specs.Platform) string {
+	if platform.OS == "" {
+		platform = platforms.DefaultSpec()
+	}
+	return fmt.Sprintf("%s %s", platforms.Format(platform), system.GetOSVersion().ToString())
 }


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/38574 for 18.09