### PR TITLE
[19.03 backport] Remove a network during task SHUTDOWN instead of REMOVE to

### DIFF
--- a/daemon/cluster/executor/container/controller.go
+++ b/daemon/cluster/executor/container/controller.go
@@ -376,6 +376,15 @@ func (r *controller) Shutdown(ctx context.Context) error {
 		return err
 	}
 
+	// Try removing networks referenced in this task in case this
+	// task is the last one referencing it
+	if err := r.adapter.removeNetworks(ctx); err != nil {
+		if isUnknownContainer(err) {
+			return nil
+		}
+		return err
+	}
+
 	return nil
 }
 
@@ -417,15 +426,6 @@ func (r *controller) Remove(ctx context.Context) error {
 		}
 		// This may fail if the task was already shut down.
 		log.G(ctx).WithError(err).Debug("shutdown failed on removal")
-	}
-
-	// Try removing networks referenced in this task in case this
-	// task is the last one referencing it
-	if err := r.adapter.removeNetworks(ctx); err != nil {
-		if isUnknownContainer(err) {
-			return nil
-		}
-		return err
 	}
 
 	if err := r.adapter.remove(ctx); err != nil {


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/39174 for 19.03


make sure the LB sandbox is removed when a service is updated
with a --network-rm option


