### PR TITLE
[19.03 backport] Switch swarmmode services to NanoCpu

### DIFF
--- a/daemon/cluster/executor/container/container.go
+++ b/daemon/cluster/executor/container/container.go
@@ -6,7 +6,6 @@ import (
 	"net"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -31,10 +30,6 @@ import (
 )
 
 const (
-	// Explicitly use the kernel's default setting for CPU quota of 100ms.
-	// https://www.kernel.org/doc/Documentation/scheduler/sched-bwc.txt
-	cpuQuotaPeriod = 100 * time.Millisecond
-
 	// systemLabelPrefix represents the reserved namespace for system labels.
 	systemLabelPrefix = "com.docker.swarm"
 )
@@ -451,9 +446,7 @@ func (c *containerConfig) resources() enginecontainer.Resources {
 	}
 
 	if r.Limits.NanoCPUs > 0 {
-		// CPU Period must be set in microseconds.
-		resources.CPUPeriod = int64(cpuQuotaPeriod / time.Microsecond)
-		resources.CPUQuota = r.Limits.NanoCPUs * resources.CPUPeriod / 1e9
+		resources.NanoCPUs = r.Limits.NanoCPUs
 	}
 
 	return resources


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/39190
fixes https://github.com/moby/moby/issues/33538


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Today `$ docker service create --limit-cpu` configures a containers `CpuPeriod` and `CpuQuota` variables, this commit switches this to configure a containers `NanoCpu` variable instead to try and fix moby/moby#33538 and provide support for limiting CPU on Windows Workloads.

This change makes  `$ docker service create --limit-cpu` the same as `$ docker run --cpu` as the later is supported on windows. https://docs.microsoft.com/en-us/virtualization/windowscontainers/manage-containers/resource-controls

The reason this change was required is because CPU Period is not supported on Windows today:

```
$ docker service create --limit-cpu "1.5" --name demo hello-world
8la8dhl7gml1biihijaxzrgwq
overall progress: 0 out of 1 tasks
1/1: invalid option: Windows does not support CPUPeriod
```

I have tested this change locally on a Linux machine and it now sets the NanoCPU setting correctly and does not set CPU Period / Quota. Note I haven't actually tested this on a Windows Machine though.

**- How I did it**

**- How to verify it**
```
$ docker swarm init

$ docker service create --name demo --limit-cpu ".5" nginx
71vtiore4fonv6dhzpxdby8x5
overall progress: 1 out of 1 tasks
1/1: running   [==================================================>]
verify: Service converged

$ docker ps
CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS              PORTS               NAMES
00fca6ed116d        nginx:latest        "nginx -g 'daemon of…"   24 seconds ago      Up 23 seconds       80/tcp              demo.1.2d6s3s9oao6yzzkyy2althpu2

$ docker inspect 00f | jq '.[].HostConfig.NanoCpus'
500000000

$ docker inspect 00f | jq '.[].HostConfig.CpuPeriod'
0

$ docker inspect 00f | jq '.[].HostConfig.CpuQuota'
0
```

**- Description for the changelog**
Support CPU constraints on Windows Swarm Services
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/10342453/57366039-1b56c480-717e-11e9-98ed-21ebf1602373.png)
