### PR TITLE
[18.09 backport] int-cli/TestSearchCmdOptions: fail earlier

### DIFF
--- a/integration-cli/docker_cli_search_test.go
+++ b/integration-cli/docker_cli_search_test.go
@@ -51,8 +51,8 @@ func (s *DockerSuite) TestSearchCmdOptions(c *check.C) {
 	assert.Assert(c, strings.Contains(out, "Usage:\tdocker search [OPTIONS] TERM"))
 
 	outSearchCmd, _ := dockerCmd(c, "search", "busybox")
+	assert.Assert(c, strings.Count(outSearchCmd, "\n") > 3, outSearchCmd)
 	outSearchCmdNotrunc, _ := dockerCmd(c, "search", "--no-trunc=true", "busybox")
-
 	assert.Assert(c, len(outSearchCmd) <= len(outSearchCmdNotrunc), "The no-trunc option can't take effect.")
 
 	outSearchCmdautomated, _ := dockerCmd(c, "search", "--filter", "is-automated=true", "busybox") //The busybox is a busybox base image, not an AUTOMATED image.
@@ -72,8 +72,8 @@ func (s *DockerSuite) TestSearchCmdOptions(c *check.C) {
 	assert.Equal(c, len(outSearchCmdOfficialSlice), 3) // 1 header, 1 line, 1 carriage return
 	assert.Assert(c, strings.HasPrefix(outSearchCmdOfficialSlice[1], "busybox "), "The busybox is an OFFICIAL image: %s", outSearchCmdOfficial)
 
-	outSearchCmdStars, _ := dockerCmd(c, "search", "--filter", "stars=2", "busybox")
-	assert.Assert(c, strings.Count(outSearchCmdStars, "[OK]") <= strings.Count(outSearchCmd, "[OK]"), "The quantity of images with stars should be less than that of all images: %s", outSearchCmdStars)
+	outSearchCmdStars, _ := dockerCmd(c, "search", "--filter", "stars=10", "busybox")
+	assert.Assert(c, strings.Count(outSearchCmdStars, "\n") <= strings.Count(outSearchCmd, "\n"), "Number of images with 10+ stars should be less than that of all images:\noutSearchCmdStars: %s\noutSearch: %s\n", outSearchCmdStars, outSearchCmd)
 
 	dockerCmd(c, "search", "--filter", "is-automated=true", "--filter", "stars=2", "--no-trunc=true", "busybox")
 


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/39243


Sometimes this test fails (allegedly due to problems with Docker Hub),
but it fails later than it should, for example:

> 01:20:34.845 assertion failed: expression is false: strings.Count(outSearchCmdStars, "[OK]") <= strings.Count(outSearchCmd, "[OK]"): The quantity of images with stars should be less than that of all images: <...>

This, with non-empty list of images following, means that the initial
`docker search busybox` command returned not enough results. So, add
a check that `docker search busybox` returns something.

While at it,
 * raise the number of stars to 10;
 * simplify check for number of lines (no need to count [OK]'s);
 * improve error message.
