### PR TITLE
[19.03 backport] builder-next: support DOCKER_RAMDISK

### DIFF
--- a/builder/builder-next/executor_unix.go
+++ b/builder/builder-next/executor_unix.go
@@ -31,6 +31,7 @@ func newExecutor(root, cgroupParent string, net libnetwork.NetworkController, ro
 		CommandCandidates:   []string{"runc"},
 		DefaultCgroupParent: cgroupParent,
 		Rootless:            rootless,
+		NoPivot:             os.Getenv("DOCKER_RAMDISK") != "",
 	}, networkProviders)
 }
 


### PR DESCRIPTION
backport https://github.com/moby/moby/pull/39202