### PR TITLE
[19.03 backport] Network not deleted after stack is removed

### DIFF
--- a/daemon/cluster/executor/container/controller.go
+++ b/daemon/cluster/executor/container/controller.go
@@ -369,20 +369,17 @@ func (r *controller) Shutdown(ctx context.Context) error {
 	}
 
 	if err := r.adapter.shutdown(ctx); err != nil {
-		if isUnknownContainer(err) || isStoppedContainer(err) {
-			return nil
+		if !(isUnknownContainer(err) || isStoppedContainer(err)) {
+			return err
 		}
-
-		return err
 	}
 
 	// Try removing networks referenced in this task in case this
 	// task is the last one referencing it
 	if err := r.adapter.removeNetworks(ctx); err != nil {
-		if isUnknownContainer(err) {
-			return nil
+		if !isUnknownContainer(err) {
+			return err
 		}
-		return err
 	}
 
 	return nil


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/39242 for 19.03

Make sure adapter.removeNetworks executes during task Remove

Fixes https://github.com/moby/moby/issues/39225

