### PR TITLE
[19.03 backport] Update TestRunWithDaemonDefaultSeccompProfile for ARM64

### DIFF
--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -1544,6 +1544,10 @@ func (s *DockerDaemonSuite) TestRunWithDaemonDefaultSeccompProfile(c *check.C) {
 		{
 			"name": "chmod",
 			"action": "SCMP_ACT_ERRNO"
+		},
+		{
+			"name": "fchmodat",
+			"action": "SCMP_ACT_ERRNO"
 		}
 	]
 }`


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/39254 - cherry pick was clean

`chmod` is a legacy syscall, and not present on arm64, which caused this test to fail.

Add `fchmodat` to the profile so that this test can run both on x64 and arm64.
