### PR TITLE
[18.09 backport] Fix error handling for bind mount spec parser.

### DIFF
--- a/volume/mounts/linux_parser.go
+++ b/volume/mounts/linux_parser.go
@@ -82,7 +82,10 @@ func (p *linuxParser) validateMountConfigImpl(mnt *mount.Mount, validateBindSour
 		}
 
 		if validateBindSourceExists {
-			exists, _, _ := currentFileInfoProvider.fileInfo(mnt.Source)
+			exists, _, err := currentFileInfoProvider.fileInfo(mnt.Source)
+			if err != nil {
+				return &errMountConfig{mnt, err}
+			}
 			if !exists {
 				return &errMountConfig{mnt, errBindSourceDoesNotExist(mnt.Source)}
 			}


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/39251 for 18.09
fixes https://github.com/docker/for-linux/issues/674 for 18.09

Errors were being ignored and always telling the user that the path
doesn't exist even if it was some other problem, such as a permission
error.

