### PR TITLE
[19.03 backport] swagger fixes

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -5462,7 +5462,7 @@ paths:
   /containers/{id}/resize:
     post:
       summary: "Resize a container TTY"
-      description: "Resize the TTY for a container. You must restart the container for the resize to take effect."
+      description: "Resize the TTY for a container."
       operationId: "ContainerResize"
       consumes:
         - "application/octet-stream"

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -9106,7 +9106,9 @@ paths:
                 type: "string"
               RemoteAddrs:
                 description: "Addresses of manager nodes already participating in the swarm."
-                type: "string"
+                type: "array"
+                items:
+                  type: "string"
               JoinToken:
                 description: "Secret token for joining this swarm."
                 type: "string"

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1141,6 +1141,7 @@ definitions:
     type: "object"
     additionalProperties:
       type: "array"
+      x-nullable: true
       items:
         $ref: "#/definitions/PortBinding"
     example:
@@ -1165,7 +1166,6 @@ definitions:
       PortBinding represents a binding between a host IP address and a host
       port.
     type: "object"
-    x-nullable: true
     properties:
       HostIp:
         description: "Host IP address that the container's port is mapped to."


### PR DESCRIPTION
backport of

- https://github.com/moby/moby/pull/39263 API: Change type of RemotrAddrs to array of strings in operation SwarmJoin
- https://github.com/moby/moby/pull/39264 API: Move "x-nullable: true" from type PortBinding to type PortMap
- https://github.com/moby/moby/pull/39265 Update docs to remove restriction of tty resize

cherry-pick was clean; no conflicts