### PR TITLE
[18.09 backport] Swagger fixes

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -5351,7 +5351,7 @@ paths:
   /containers/{id}/resize:
     post:
       summary: "Resize a container TTY"
-      description: "Resize the TTY for a container. You must restart the container for the resize to take effect."
+      description: "Resize the TTY for a container."
       operationId: "ContainerResize"
       consumes:
         - "application/octet-stream"

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -6105,6 +6105,10 @@ paths:
           in: "query"
           description: "If “1”, “true”, or “True” then it will be an error if unpacking the given content would cause an existing directory to be replaced with a non-directory and vice versa."
           type: "string"
+        - name: "copyUIDGID"
+          in: "query"
+          description: "If “1”, “true”, then it will copy UID/GID maps to the dest file or dir"
+          type: "string"
         - name: "inputStream"
           in: "body"
           required: true

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -8932,7 +8932,9 @@ paths:
                 type: "string"
               RemoteAddrs:
                 description: "Addresses of manager nodes already participating in the swarm."
-                type: "string"
+                type: "array"
+                items:
+                  type: "string"
               JoinToken:
                 description: "Secret token for joining this swarm."
                 type: "string"

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1082,6 +1082,7 @@ definitions:
     type: "object"
     additionalProperties:
       type: "array"
+      x-nullable: true
       items:
         $ref: "#/definitions/PortBinding"
     example:
@@ -1106,7 +1107,6 @@ definitions:
       PortBinding represents a binding between a host IP address and a host
       port.
     type: "object"
-    x-nullable: true
     properties:
       HostIp:
         description: "Host IP address that the container's port is mapped to."

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -6111,6 +6111,7 @@ paths:
           description: "The input stream must be a tar archive compressed with one of the following algorithms: identity (no compression), gzip, bzip2, xz."
           schema:
             type: "string"
+            format: "binary"
       tags: ["Container"]
   /containers/prune:
     post:

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -159,6 +159,7 @@ keywords: "API, Docker, rcli, REST, documentation"
 * `GET /events` now supports service, node and secret events which are emitted when users create, update and remove service, node and secret
 * `GET /events` now supports network remove event which is emitted when users remove a swarm scoped network
 * `GET /events` now supports a filter type `scope` in which supported value could be swarm and local
+* `PUT /containers/(name)/archive` now accepts a `copyUIDGID` parameter to allow copy UID/GID maps to dest file or dir.
 
 ## v1.29 API changes
 


### PR DESCRIPTION
backport of

- https://github.com/moby/moby/pull/39263 API: Change type of RemotrAddrs to array of strings in operation SwarmJoin
- https://github.com/moby/moby/pull/39264 API: Move "x-nullable: true" from type PortBinding to type PortMap
- https://github.com/moby/moby/pull/39265 Update docs to remove restriction of tty resize
- https://github.com/moby/moby/pull/39248 API: Set format of body parameter in operation PutContainerArchive to "binary" 
- https://github.com/moby/moby/pull/39279 fix: fix lack of copyUIDGID in swagger.yaml

cherry-pick was clean; no conflicts