### PR TITLE
[18.09 backport] image: do actual RootFS.DiffIDs copying in Clone()

### DIFF
--- a/image/rootfs.go
+++ b/image/rootfs.go
@@ -38,7 +38,8 @@ func (r *RootFS) Append(id layer.DiffID) {
 func (r *RootFS) Clone() *RootFS {
 	newRoot := NewRootFS()
 	newRoot.Type = r.Type
-	newRoot.DiffIDs = append(r.DiffIDs)
+	newRoot.DiffIDs = make([]layer.DiffID, len(r.DiffIDs))
+	copy(newRoot.DiffIDs, r.DiffIDs)
 	return newRoot
 }
 


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/38888 for 18.09

append(newRoot.DiffIDs) without element does nothing,
so it's probably not what was intended. Changed code
to perform a slice copying instead.

Fixes #38834.
