### PR TITLE
[19.03 backport] API: Set format of body parameter in operation PutContainerArchive to "binary"

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -6222,6 +6222,7 @@ paths:
           description: "The input stream must be a tar archive compressed with one of the following algorithms: identity (no compression), gzip, bzip2, xz."
           schema:
             type: "string"
+            format: "binary"
       tags: ["Container"]
   /containers/prune:
     post:


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/39248 for 19.03