### PR TITLE
[19.03 backport] Revert docker/swarmkit#2804

### DIFF
--- a/integration/service/update_test.go
+++ b/integration/service/update_test.go
@@ -33,7 +33,7 @@ func TestServiceUpdateLabel(t *testing.T) {
 	service.Spec.Labels["foo"] = "bar"
 	_, err := cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, types.ServiceUpdateOptions{})
 	assert.NilError(t, err)
-	poll.WaitOn(t, serviceIsUpdated(cli, serviceID), swarm.ServicePoll)
+	poll.WaitOn(t, serviceSpecIsUpdated(cli, serviceID, service.Version.Index), swarm.ServicePoll)
 	service = getService(t, cli, serviceID)
 	assert.Check(t, is.DeepEqual(service.Spec.Labels, map[string]string{"foo": "bar"}))
 
@@ -41,21 +41,21 @@ func TestServiceUpdateLabel(t *testing.T) {
 	service.Spec.Labels["foo2"] = "bar"
 	_, err = cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, types.ServiceUpdateOptions{})
 	assert.NilError(t, err)
-	poll.WaitOn(t, serviceIsUpdated(cli, serviceID), swarm.ServicePoll)
+	poll.WaitOn(t, serviceSpecIsUpdated(cli, serviceID, service.Version.Index), swarm.ServicePoll)
 	service = getService(t, cli, serviceID)
 	assert.Check(t, is.DeepEqual(service.Spec.Labels, map[string]string{"foo": "bar", "foo2": "bar"}))
 
 	delete(service.Spec.Labels, "foo2")
 	_, err = cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, types.ServiceUpdateOptions{})
 	assert.NilError(t, err)
-	poll.WaitOn(t, serviceIsUpdated(cli, serviceID), swarm.ServicePoll)
+	poll.WaitOn(t, serviceSpecIsUpdated(cli, serviceID, service.Version.Index), swarm.ServicePoll)
 	service = getService(t, cli, serviceID)
 	assert.Check(t, is.DeepEqual(service.Spec.Labels, map[string]string{"foo": "bar"}))
 
 	delete(service.Spec.Labels, "foo")
 	_, err = cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, types.ServiceUpdateOptions{})
 	assert.NilError(t, err)
-	poll.WaitOn(t, serviceIsUpdated(cli, serviceID), swarm.ServicePoll)
+	poll.WaitOn(t, serviceSpecIsUpdated(cli, serviceID, service.Version.Index), swarm.ServicePoll)
 	service = getService(t, cli, serviceID)
 	assert.Check(t, is.DeepEqual(service.Spec.Labels, map[string]string{}))
 
@@ -63,7 +63,7 @@ func TestServiceUpdateLabel(t *testing.T) {
 	service.Spec.Labels["foo"] = "bar"
 	_, err = cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, types.ServiceUpdateOptions{})
 	assert.NilError(t, err)
-	poll.WaitOn(t, serviceIsUpdated(cli, serviceID), swarm.ServicePoll)
+	poll.WaitOn(t, serviceSpecIsUpdated(cli, serviceID, service.Version.Index), swarm.ServicePoll)
 	service = getService(t, cli, serviceID)
 	assert.Check(t, is.DeepEqual(service.Spec.Labels, map[string]string{"foo": "bar"}))
 
@@ -267,6 +267,20 @@ func serviceIsUpdated(client client.ServiceAPIClient, serviceID string) func(log
 			if service.UpdateStatus != nil {
 				return poll.Continue("waiting for service %s to be updated, state: %s, message: %s", serviceID, service.UpdateStatus.State, service.UpdateStatus.Message)
 			}
+			return poll.Continue("waiting for service %s to be updated", serviceID)
+		}
+	}
+}
+
+func serviceSpecIsUpdated(client client.ServiceAPIClient, serviceID string, serviceOldVersion uint64) func(log poll.LogT) poll.Result {
+	return func(log poll.LogT) poll.Result {
+		service, _, err := client.ServiceInspectWithRaw(context.Background(), serviceID, types.ServiceInspectOptions{})
+		switch {
+		case err != nil:
+			return poll.Error(err)
+		case service.Version.Index > serviceOldVersion:
+			return poll.Success()
+		default:
 			return poll.Continue("waiting for service %s to be updated", serviceID)
 		}
 	}

--- a/vendor.conf
+++ b/vendor.conf
@@ -130,7 +130,7 @@ github.com/containerd/ttrpc                         f02858b1457c5ca3aaec3a0803eb
 github.com/gogo/googleapis                          d31c731455cb061f42baff3bda55bad0118b126b # v1.2.0
 
 # cluster
-github.com/docker/swarmkit                          48eb1828ce81be20b25d647f6ca8f33d599f705c
+github.com/docker/swarmkit                          961ec3a56b7b6c311a2137b6a398f9d778fba94b # bump_v19.03 branch
 github.com/gogo/protobuf                            ba06b47c162d49f2af050fb4c75bcbc86a159d5c # v1.2.1
 github.com/cloudflare/cfssl                         5d63dbd981b5c408effbb58c442d54761ff94fbd # 1.3.2
 github.com/fernet/fernet-go                         1b2437bc582b3cfbb341ee5a29f8ef5b42912ff2

--- a/vendor/github.com/docker/swarmkit/manager/orchestrator/update/updater.go
+++ b/vendor/github.com/docker/swarmkit/manager/orchestrator/update/updater.go
@@ -141,17 +141,10 @@ func (u *Updater) Run(ctx context.Context, slots []orchestrator.Slot) {
 	}
 	// Abort immediately if all tasks are clean.
 	if len(dirtySlots) == 0 {
-		if service.UpdateStatus == nil {
-			if u.annotationsUpdated(service) {
-				// Annotation-only update; mark the update as completed
-				u.completeUpdate(ctx, service.ID, true)
-			}
-			return
-		}
-		if service.UpdateStatus.State == api.UpdateStatus_UPDATING || service.UpdateStatus.State == api.UpdateStatus_ROLLBACK_STARTED {
-			// Update or rollback was started, and is now complete
-			u.completeUpdate(ctx, service.ID, true)
-			return
+		if service.UpdateStatus != nil &&
+			(service.UpdateStatus.State == api.UpdateStatus_UPDATING ||
+				service.UpdateStatus.State == api.UpdateStatus_ROLLBACK_STARTED) {
+			u.completeUpdate(ctx, service.ID)
 		}
 		return
 	}
@@ -310,7 +303,7 @@ slotsLoop:
 	// have reached RUNNING by this point.
 
 	if !stopped {
-		u.completeUpdate(ctx, service.ID, false)
+		u.completeUpdate(ctx, service.ID)
 	}
 }
 
@@ -623,32 +616,25 @@ func (u *Updater) rollbackUpdate(ctx context.Context, serviceID, message string)
 	}
 }
 
-func (u *Updater) completeUpdate(ctx context.Context, serviceID string, force bool) {
+func (u *Updater) completeUpdate(ctx context.Context, serviceID string) {
 	log.G(ctx).Debugf("update of service %s complete", serviceID)
 
 	err := u.store.Update(func(tx store.Tx) error {
 		service := store.GetService(tx, serviceID)
-		switch {
-		case service == nil:
+		if service == nil {
 			return nil
-		case service.UpdateStatus == nil && force:
-			// Force marking the status as updated; to account for annotation-only updates.
-			service.UpdateStatus = &api.UpdateStatus{
-				StartedAt: ptypes.MustTimestampProto(time.Now()),
-				State:     api.UpdateStatus_COMPLETED,
-				Message:   "update completed",
-			}
-		case service.UpdateStatus == nil:
+		}
+		if service.UpdateStatus == nil {
 			// The service was changed since we started this update
 			return nil
-		case service.UpdateStatus.State == api.UpdateStatus_ROLLBACK_STARTED:
+		}
+		if service.UpdateStatus.State == api.UpdateStatus_ROLLBACK_STARTED {
 			service.UpdateStatus.State = api.UpdateStatus_ROLLBACK_COMPLETED
 			service.UpdateStatus.Message = "rollback completed"
-		default:
+		} else {
 			service.UpdateStatus.State = api.UpdateStatus_COMPLETED
 			service.UpdateStatus.Message = "update completed"
 		}
-
 		service.UpdateStatus.CompletedAt = ptypes.MustTimestampProto(time.Now())
 
 		return store.UpdateService(tx, service)
@@ -657,11 +643,4 @@ func (u *Updater) completeUpdate(ctx context.Context, serviceID string, force bo
 	if err != nil {
 		log.G(ctx).WithError(err).Errorf("failed to mark update of service %s complete", serviceID)
 	}
-}
-
-func (u *Updater) annotationsUpdated(service *api.Service) bool {
-	if service.PreviousSpec == nil {
-		return false
-	}
-	return !reflect.DeepEqual(service.Spec, service.PreviousSpec)
 }


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/39281 for 19.03.

Local changes applied cleanly, but the vendor.conf did not; fixed by changing `vendor.conf` to point to the bump_v19.03 branch (which includes https://github.com/docker/swarmkit/pull/2863), and running `vndr` again.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Reverts the change to swarmkit that made all updates set UpdateStatus to Completed.

See docker/swarmkit#2861


related: https://github.com/docker/swarmkit/pull/2804, https://github.com/moby/moby/pull/38520


fixes https://github.com/docker/swarmkit/issues/2861
fixes https://github.com/moby/moby/issues/39023


**- How I did it**

Returned the integration test to the way it was before