### PR TITLE
[19.03 backport] build: fix panic when exporting to tar

### DIFF
--- a/api/server/backend/build/backend.go
+++ b/api/server/backend/build/backend.go
@@ -91,7 +91,9 @@ func (b *Backend) Build(ctx context.Context, config backend.BuildConfig) (string
 		stdout := config.ProgressWriter.StdoutFormatter
 		fmt.Fprintf(stdout, "Successfully built %s\n", stringid.TruncateID(imageID))
 	}
-	err = tagger.TagImages(image.ID(imageID))
+	if imageID != "" {
+		err = tagger.TagImages(image.ID(imageID))
+	}
 	return imageID, err
 }
 


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/39310 for 19.03

Fixes a panic on `docker build -t foo -o - . >/dev/null`
