### PR TITLE
[19.03 backport] Handle the error case when a container reattaches to the same network

### DIFF
--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -354,6 +354,14 @@ func (daemon *Daemon) findAndAttachNetwork(container *container.Container, idOrN
 		if container.Managed || !n.Info().Dynamic() {
 			return n, nil, nil
 		}
+		// Throw an error if the container is already attached to the network
+		if container.NetworkSettings.Networks != nil {
+			networkName := n.Name()
+			containerName := strings.TrimPrefix(container.Name, "/")
+			if network, ok := container.NetworkSettings.Networks[networkName]; ok && network.EndpointID != "" {
+				return n, nil, types.ForbiddenErrorf("%s is already attached to network %s", containerName, networkName)
+			}
+		}
 	}
 
 	var addresses []string

--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -359,7 +359,8 @@ func (daemon *Daemon) findAndAttachNetwork(container *container.Container, idOrN
 			networkName := n.Name()
 			containerName := strings.TrimPrefix(container.Name, "/")
 			if network, ok := container.NetworkSettings.Networks[networkName]; ok && network.EndpointID != "" {
-				return n, nil, types.ForbiddenErrorf("%s is already attached to network %s", containerName, networkName)
+				err := fmt.Errorf("%s is already attached to network %s", containerName, networkName)
+				return n, nil, errdefs.Conflict(err)
 			}
 		}
 	}

--- a/integration/service/network_test.go
+++ b/integration/service/network_test.go
@@ -75,3 +75,43 @@ func TestDockerNetworkConnectAlias(t *testing.T) {
 	assert.Check(t, is.Equal(len(ng2.NetworkSettings.Networks[name].Aliases), 2))
 	assert.Check(t, is.Equal(ng2.NetworkSettings.Networks[name].Aliases[0], "bbb"))
 }
+
+func TestDockerNetworkReConnect(t *testing.T) {
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
+	defer setupTest(t)()
+	d := swarm.NewSwarm(t, testEnv)
+	defer d.Stop(t)
+	client := d.NewClientT(t)
+	defer client.Close()
+	ctx := context.Background()
+
+	name := t.Name() + "dummyNet"
+	net.CreateNoError(t, ctx, client, name,
+		net.WithDriver("overlay"),
+		net.WithAttachable(),
+	)
+
+	c1 := container.Create(t, ctx, client, func(c *container.TestContainerConfig) {
+		c.NetworkingConfig = &network.NetworkingConfig{
+			EndpointsConfig: map[string]*network.EndpointSettings{
+				name: {},
+			},
+		}
+	})
+
+	err := client.NetworkConnect(ctx, name, c1, &network.EndpointSettings{})
+	assert.NilError(t, err)
+
+	err = client.ContainerStart(ctx, c1, types.ContainerStartOptions{})
+	assert.NilError(t, err)
+
+	n1, err := client.ContainerInspect(ctx, c1)
+	assert.NilError(t, err)
+
+	err = client.NetworkConnect(ctx, name, c1, &network.EndpointSettings{})
+	assert.ErrorContains(t, err, "is already attached to network")
+
+	n2, err := client.ContainerInspect(ctx, c1)
+	assert.NilError(t, err)
+	assert.Check(t, is.DeepEqual(n1, n2))
+}


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/39137 for 19.03

Fixes - https://github.com/docker/for-linux/issues/632

Signed-off-by: Arko Dasgupta <arko.dasgupta@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Made sure the Networks context is manipulated in the scenario when a container attempts to attach to an a network it is already connected to

**- How I did it**
When attaching to a network in `findAndAttachNetwork` make sure you return with an error when that network is already part of `container.NetworkSettings.Networks`

**- How to verify it**
Followed the same steps in the issue and made sure it is resolved

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
