### PR TITLE
[19.03 backport] Integration: change signatures to fix golint warnings

### DIFF
--- a/integration/build/build_squash_test.go
+++ b/integration/build/build_squash_test.go
@@ -79,7 +79,7 @@ func TestBuildSquashParent(t *testing.T) {
 	resp.Body.Close()
 	assert.NilError(t, err)
 
-	cid := container.Run(t, ctx, client,
+	cid := container.Run(ctx, t, client,
 		container.WithImage(name),
 		container.WithCmd("/bin/sh", "-c", "cat /hello"),
 	)
@@ -94,11 +94,11 @@ func TestBuildSquashParent(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(strings.TrimSpace(actualStdout.String()), "hello\nworld"))
 
-	container.Run(t, ctx, client,
+	container.Run(ctx, t, client,
 		container.WithImage(name),
 		container.WithCmd("/bin/sh", "-c", "[ ! -f /remove_me ]"),
 	)
-	container.Run(t, ctx, client,
+	container.Run(ctx, t, client,
 		container.WithImage(name),
 		container.WithCmd("/bin/sh", "-c", `[ "$(echo $HELLO)" == "world" ]`),
 	)

--- a/integration/container/checkpoint_test.go
+++ b/integration/container/checkpoint_test.go
@@ -50,7 +50,7 @@ func TestCheckpoint(t *testing.T) {
 	}
 
 	t.Log("Start a container")
-	cID := container.Run(t, ctx, client, container.WithMount(mnt))
+	cID := container.Run(ctx, t, client, container.WithMount(mnt))
 	poll.WaitOn(t,
 		container.IsInState(ctx, client, cID, "running"),
 		poll.WithDelay(100*time.Millisecond),

--- a/integration/container/copy_test.go
+++ b/integration/container/copy_test.go
@@ -105,7 +105,7 @@ func TestCopyFromContainer(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Assert(t, imageID != "")
 
-	cid := container.Create(t, ctx, apiClient, container.WithImage(imageID))
+	cid := container.Create(ctx, t, apiClient, container.WithImage(imageID))
 
 	for _, x := range []struct {
 		src    string

--- a/integration/container/copy_test.go
+++ b/integration/container/copy_test.go
@@ -26,7 +26,7 @@ func TestCopyFromContainerPathDoesNotExist(t *testing.T) {
 
 	ctx := context.Background()
 	apiclient := testEnv.APIClient()
-	cid := container.Create(t, ctx, apiclient)
+	cid := container.Create(ctx, t, apiclient)
 
 	_, _, err := apiclient.CopyFromContainer(ctx, cid, "/dne")
 	assert.Check(t, client.IsErrNotFound(err))
@@ -40,7 +40,7 @@ func TestCopyFromContainerPathIsNotDir(t *testing.T) {
 
 	ctx := context.Background()
 	apiclient := testEnv.APIClient()
-	cid := container.Create(t, ctx, apiclient)
+	cid := container.Create(ctx, t, apiclient)
 
 	_, _, err := apiclient.CopyFromContainer(ctx, cid, "/etc/passwd/")
 	assert.Assert(t, is.ErrorContains(err, "not a directory"))
@@ -52,7 +52,7 @@ func TestCopyToContainerPathDoesNotExist(t *testing.T) {
 
 	ctx := context.Background()
 	apiclient := testEnv.APIClient()
-	cid := container.Create(t, ctx, apiclient)
+	cid := container.Create(ctx, t, apiclient)
 
 	err := apiclient.CopyToContainer(ctx, cid, "/dne", nil, types.CopyToContainerOptions{})
 	assert.Check(t, client.IsErrNotFound(err))
@@ -66,7 +66,7 @@ func TestCopyToContainerPathIsNotDir(t *testing.T) {
 
 	ctx := context.Background()
 	apiclient := testEnv.APIClient()
-	cid := container.Create(t, ctx, apiclient)
+	cid := container.Create(ctx, t, apiclient)
 
 	err := apiclient.CopyToContainer(ctx, cid, "/etc/passwd/", nil, types.CopyToContainerOptions{})
 	assert.Assert(t, is.ErrorContains(err, "not a directory"))

--- a/integration/container/daemon_linux_test.go
+++ b/integration/container/daemon_linux_test.go
@@ -40,7 +40,7 @@ func TestContainerStartOnDaemonRestart(t *testing.T) {
 
 	ctx := context.Background()
 
-	cID := container.Create(t, ctx, c)
+	cID := container.Create(ctx, t, c)
 	defer c.ContainerRemove(ctx, cID, types.ContainerRemoveOptions{Force: true})
 
 	err := c.ContainerStart(ctx, cID, types.ContainerStartOptions{})

--- a/integration/container/daemon_linux_test.go
+++ b/integration/container/daemon_linux_test.go
@@ -94,7 +94,7 @@ func TestDaemonRestartIpcMode(t *testing.T) {
 	ctx := context.Background()
 
 	// check the container is created with private ipc mode as per daemon default
-	cID := container.Run(t, ctx, c,
+	cID := container.Run(ctx, t, c,
 		container.WithCmd("top"),
 		container.WithRestartPolicy("always"),
 	)
@@ -113,7 +113,7 @@ func TestDaemonRestartIpcMode(t *testing.T) {
 	assert.Check(t, is.Equal(string(inspect.HostConfig.IpcMode), "private"))
 
 	// check a new container is created with shareable ipc mode as per new daemon default
-	cID = container.Run(t, ctx, c)
+	cID = container.Run(ctx, t, c)
 	defer c.ContainerRemove(ctx, cID, types.ContainerRemoveOptions{Force: true})
 
 	inspect, err = c.ContainerInspect(ctx, cID)

--- a/integration/container/diff_test.go
+++ b/integration/container/diff_test.go
@@ -19,7 +19,7 @@ func TestDiff(t *testing.T) {
 	client := testEnv.APIClient()
 	ctx := context.Background()
 
-	cID := container.Run(t, ctx, client, container.WithCmd("sh", "-c", `mkdir /foo; echo xyzzy > /foo/bar`))
+	cID := container.Run(ctx, t, client, container.WithCmd("sh", "-c", `mkdir /foo; echo xyzzy > /foo/bar`))
 
 	// Wait for it to exit as cannot diff a running container on Windows, and
 	// it will take a few seconds to exit. Also there's no way in Windows to

--- a/integration/container/exec_test.go
+++ b/integration/container/exec_test.go
@@ -24,7 +24,7 @@ func TestExecWithCloseStdin(t *testing.T) {
 	client := testEnv.APIClient()
 
 	// run top with detached mode
-	cID := container.Run(t, ctx, client)
+	cID := container.Run(ctx, t, client)
 
 	expected := "closeIO"
 	execResp, err := client.ContainerExecCreate(ctx, cID,
@@ -90,7 +90,7 @@ func TestExec(t *testing.T) {
 	ctx := context.Background()
 	client := testEnv.APIClient()
 
-	cID := container.Run(t, ctx, client, container.WithTty(true), container.WithWorkingDir("/root"))
+	cID := container.Run(ctx, t, client, container.WithTty(true), container.WithWorkingDir("/root"))
 
 	id, err := client.ContainerExecCreate(ctx, cID,
 		types.ExecConfig{
@@ -125,7 +125,7 @@ func TestExecUser(t *testing.T) {
 	ctx := context.Background()
 	client := testEnv.APIClient()
 
-	cID := container.Run(t, ctx, client, container.WithTty(true), container.WithUser("1:1"))
+	cID := container.Run(ctx, t, client, container.WithTty(true), container.WithUser("1:1"))
 
 	result, err := container.Exec(ctx, client, cID, []string{"id"})
 	assert.NilError(t, err)

--- a/integration/container/export_test.go
+++ b/integration/container/export_test.go
@@ -25,7 +25,7 @@ func TestExportContainerAndImportImage(t *testing.T) {
 	client := testEnv.APIClient()
 	ctx := context.Background()
 
-	cID := container.Run(t, ctx, client, container.WithCmd("true"))
+	cID := container.Run(ctx, t, client, container.WithCmd("true"))
 	poll.WaitOn(t, container.IsStopped(ctx, client, cID), poll.WithDelay(100*time.Millisecond))
 
 	reference := "repo/testexp:v1"

--- a/integration/container/export_test.go
+++ b/integration/container/export_test.go
@@ -67,7 +67,7 @@ func TestExportContainerAfterDaemonRestart(t *testing.T) {
 	defer d.Stop(t)
 
 	ctx := context.Background()
-	ctrID := container.Create(t, ctx, c)
+	ctrID := container.Create(ctx, t, c)
 
 	d.Restart(t)
 

--- a/integration/container/health_test.go
+++ b/integration/container/health_test.go
@@ -42,7 +42,7 @@ func TestHealthKillContainer(t *testing.T) {
 	ctx := context.Background()
 	client := testEnv.APIClient()
 
-	id := container.Run(t, ctx, client, func(c *container.TestContainerConfig) {
+	id := container.Run(ctx, t, client, func(c *container.TestContainerConfig) {
 		c.Config.Healthcheck = &containertypes.HealthConfig{
 			Test:     []string{"CMD-SHELL", "sleep 1"},
 			Interval: time.Second,

--- a/integration/container/health_test.go
+++ b/integration/container/health_test.go
@@ -22,7 +22,7 @@ func TestHealthCheckWorkdir(t *testing.T) {
 	ctx := context.Background()
 	client := testEnv.APIClient()
 
-	cID := container.Run(t, ctx, client, container.WithTty(true), container.WithWorkingDir("/foo"), func(c *container.TestContainerConfig) {
+	cID := container.Run(ctx, t, client, container.WithTty(true), container.WithWorkingDir("/foo"), func(c *container.TestContainerConfig) {
 		c.Config.Healthcheck = &containertypes.HealthConfig{
 			Test:     []string{"CMD-SHELL", "if [ \"$PWD\" = \"/foo\" ]; then exit 0; else exit 1; fi;"},
 			Interval: 50 * time.Millisecond,

--- a/integration/container/inspect_test.go
+++ b/integration/container/inspect_test.go
@@ -24,7 +24,7 @@ func TestInspectCpusetInConfigPre120(t *testing.T) {
 
 	name := "cpusetinconfig-pre120-" + t.Name()
 	// Create container with up to-date-API
-	container.Run(t, ctx, request.NewAPIClient(t), container.WithName(name),
+	container.Run(ctx, t, request.NewAPIClient(t), container.WithName(name),
 		container.WithCmd("true"),
 		func(c *container.TestContainerConfig) {
 			c.HostConfig.Resources.CpusetCpus = "0"

--- a/integration/container/ipcmode_linux_test.go
+++ b/integration/container/ipcmode_linux_test.go
@@ -308,7 +308,7 @@ func TestIpcModeOlderClient(t *testing.T) {
 	ctx := context.Background()
 
 	// pre-check: default ipc mode in daemon is private
-	cID := container.Create(t, ctx, c, container.WithAutoRemove)
+	cID := container.Create(ctx, t, c, container.WithAutoRemove)
 
 	inspect, err := c.ContainerInspect(ctx, cID)
 	assert.NilError(t, err)
@@ -316,7 +316,7 @@ func TestIpcModeOlderClient(t *testing.T) {
 
 	// main check: using older client creates "shareable" container
 	c = request.NewAPIClient(t, client.WithVersion("1.39"))
-	cID = container.Create(t, ctx, c, container.WithAutoRemove)
+	cID = container.Create(ctx, t, c, container.WithAutoRemove)
 
 	inspect, err = c.ContainerInspect(ctx, cID)
 	assert.NilError(t, err)

--- a/integration/container/kill_test.go
+++ b/integration/container/kill_test.go
@@ -113,7 +113,7 @@ func TestKillStoppedContainer(t *testing.T) {
 	defer setupTest(t)()
 	ctx := context.Background()
 	client := testEnv.APIClient()
-	id := container.Create(t, ctx, client)
+	id := container.Create(ctx, t, client)
 	err := client.ContainerKill(ctx, id, "SIGKILL")
 	assert.Assert(t, is.ErrorContains(err, ""))
 	assert.Assert(t, is.Contains(err.Error(), "is not running"))
@@ -124,7 +124,7 @@ func TestKillStoppedContainerAPIPre120(t *testing.T) {
 	defer setupTest(t)()
 	ctx := context.Background()
 	client := request.NewAPIClient(t, client.WithVersion("1.19"))
-	id := container.Create(t, ctx, client)
+	id := container.Create(ctx, t, client)
 	err := client.ContainerKill(ctx, id, "SIGKILL")
 	assert.NilError(t, err)
 }

--- a/integration/container/kill_test.go
+++ b/integration/container/kill_test.go
@@ -18,7 +18,7 @@ func TestKillContainerInvalidSignal(t *testing.T) {
 	defer setupTest(t)()
 	client := testEnv.APIClient()
 	ctx := context.Background()
-	id := container.Run(t, ctx, client)
+	id := container.Run(ctx, t, client)
 
 	err := client.ContainerKill(ctx, id, "0")
 	assert.Error(t, err, "Error response from daemon: Invalid signal: 0")
@@ -60,7 +60,7 @@ func TestKillContainer(t *testing.T) {
 		tc := tc
 		t.Run(tc.doc, func(t *testing.T) {
 			ctx := context.Background()
-			id := container.Run(t, ctx, client)
+			id := container.Run(ctx, t, client)
 			err := client.ContainerKill(ctx, id, tc.signal)
 			assert.NilError(t, err)
 
@@ -95,7 +95,7 @@ func TestKillWithStopSignalAndRestartPolicies(t *testing.T) {
 		tc := tc
 		t.Run(tc.doc, func(t *testing.T) {
 			ctx := context.Background()
-			id := container.Run(t, ctx, client,
+			id := container.Run(ctx, t, client,
 				container.WithRestartPolicy("always"),
 				func(c *container.TestContainerConfig) {
 					c.Config.StopSignal = tc.stopsignal
@@ -137,7 +137,7 @@ func TestKillDifferentUserContainer(t *testing.T) {
 	ctx := context.Background()
 	client := request.NewAPIClient(t, client.WithVersion("1.19"))
 
-	id := container.Run(t, ctx, client, func(c *container.TestContainerConfig) {
+	id := container.Run(ctx, t, client, func(c *container.TestContainerConfig) {
 		c.Config.User = "daemon"
 	})
 	poll.WaitOn(t, container.IsInState(ctx, client, id, "running"), poll.WithDelay(100*time.Millisecond))
@@ -154,7 +154,7 @@ func TestInspectOomKilledTrue(t *testing.T) {
 	ctx := context.Background()
 	client := testEnv.APIClient()
 
-	cID := container.Run(t, ctx, client, container.WithCmd("sh", "-c", "x=a; while true; do x=$x$x$x$x; done"), func(c *container.TestContainerConfig) {
+	cID := container.Run(ctx, t, client, container.WithCmd("sh", "-c", "x=a; while true; do x=$x$x$x$x; done"), func(c *container.TestContainerConfig) {
 		c.HostConfig.Resources.Memory = 32 * 1024 * 1024
 	})
 
@@ -172,7 +172,7 @@ func TestInspectOomKilledFalse(t *testing.T) {
 	ctx := context.Background()
 	client := testEnv.APIClient()
 
-	cID := container.Run(t, ctx, client, container.WithCmd("sh", "-c", "echo hello world"))
+	cID := container.Run(ctx, t, client, container.WithCmd("sh", "-c", "echo hello world"))
 
 	poll.WaitOn(t, container.IsInState(ctx, client, cID, "exited"), poll.WithDelay(100*time.Millisecond))
 

--- a/integration/container/links_linux_test.go
+++ b/integration/container/links_linux_test.go
@@ -24,7 +24,7 @@ func TestLinksEtcHostsContentMatch(t *testing.T) {
 	client := testEnv.APIClient()
 	ctx := context.Background()
 
-	cID := container.Run(t, ctx, client, container.WithNetworkMode("host"))
+	cID := container.Run(ctx, t, client, container.WithNetworkMode("host"))
 	res, err := container.Exec(ctx, client, cID, []string{"cat", "/etc/hosts"})
 	assert.NilError(t, err)
 	assert.Assert(t, is.Len(res.Stderr(), 0))
@@ -42,8 +42,8 @@ func TestLinksContainerNames(t *testing.T) {
 
 	containerA := "first_" + t.Name()
 	containerB := "second_" + t.Name()
-	container.Run(t, ctx, client, container.WithName(containerA))
-	container.Run(t, ctx, client, container.WithName(containerB), container.WithLinks(containerA+":"+containerA))
+	container.Run(ctx, t, client, container.WithName(containerA))
+	container.Run(ctx, t, client, container.WithName(containerB), container.WithLinks(containerA+":"+containerA))
 
 	f := filters.NewArgs(filters.Arg("name", containerA))
 

--- a/integration/container/logs_test.go
+++ b/integration/container/logs_test.go
@@ -21,7 +21,7 @@ func TestLogsFollowTailEmpty(t *testing.T) {
 	client := testEnv.APIClient()
 	ctx := context.Background()
 
-	id := container.Run(t, ctx, client, container.WithCmd("sleep", "100000"))
+	id := container.Run(ctx, t, client, container.WithCmd("sleep", "100000"))
 
 	logs, err := client.ContainerLogs(ctx, id, types.ContainerLogsOptions{ShowStdout: true, Tail: "2"})
 	if logs != nil {

--- a/integration/container/mounts_linux_test.go
+++ b/integration/container/mounts_linux_test.go
@@ -256,9 +256,9 @@ func TestContainerBindMountNonRecursive(t *testing.T) {
 	ctx := context.Background()
 	client := testEnv.APIClient()
 	containers := []string{
-		container.Run(t, ctx, client, container.WithMount(implicit), container.WithCmd(recursiveVerifier...)),
-		container.Run(t, ctx, client, container.WithMount(recursive), container.WithCmd(recursiveVerifier...)),
-		container.Run(t, ctx, client, container.WithMount(nonRecursive), container.WithCmd(nonRecursiveVerifier...)),
+		container.Run(ctx, t, client, container.WithMount(implicit), container.WithCmd(recursiveVerifier...)),
+		container.Run(ctx, t, client, container.WithMount(recursive), container.WithCmd(recursiveVerifier...)),
+		container.Run(ctx, t, client, container.WithMount(nonRecursive), container.WithCmd(nonRecursiveVerifier...)),
 	}
 
 	for _, c := range containers {

--- a/integration/container/nat_test.go
+++ b/integration/container/nat_test.go
@@ -71,7 +71,7 @@ func TestNetworkLoopbackNat(t *testing.T) {
 	client := testEnv.APIClient()
 	ctx := context.Background()
 
-	cID := container.Run(t, ctx, client, container.WithCmd("sh", "-c", fmt.Sprintf("stty raw && nc -w 5 %s 8080", endpoint.String())), container.WithTty(true), container.WithNetworkMode("container:"+serverContainerID))
+	cID := container.Run(ctx, t, client, container.WithCmd("sh", "-c", fmt.Sprintf("stty raw && nc -w 5 %s 8080", endpoint.String())), container.WithTty(true), container.WithNetworkMode("container:"+serverContainerID))
 
 	poll.WaitOn(t, container.IsStopped(ctx, client, cID), poll.WithDelay(100*time.Millisecond))
 
@@ -93,7 +93,7 @@ func startServerContainer(t *testing.T, msg string, port int) string {
 	client := testEnv.APIClient()
 	ctx := context.Background()
 
-	cID := container.Run(t, ctx, client, container.WithName("server-"+t.Name()), container.WithCmd("sh", "-c", fmt.Sprintf("echo %q | nc -lp %d", msg, port)), container.WithExposedPorts(fmt.Sprintf("%d/tcp", port)), func(c *container.TestContainerConfig) {
+	cID := container.Run(ctx, t, client, container.WithName("server-"+t.Name()), container.WithCmd("sh", "-c", fmt.Sprintf("echo %q | nc -lp %d", msg, port)), container.WithExposedPorts(fmt.Sprintf("%d/tcp", port)), func(c *container.TestContainerConfig) {
 		c.HostConfig.PortBindings = nat.PortMap{
 			nat.Port(fmt.Sprintf("%d/tcp", port)): []nat.PortBinding{
 				{

--- a/integration/container/pause_test.go
+++ b/integration/container/pause_test.go
@@ -25,7 +25,7 @@ func TestPause(t *testing.T) {
 	client := testEnv.APIClient()
 	ctx := context.Background()
 
-	cID := container.Run(t, ctx, client)
+	cID := container.Run(ctx, t, client)
 	poll.WaitOn(t, container.IsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
 
 	since := request.DaemonUnixTime(ctx, t, client, testEnv)
@@ -57,7 +57,7 @@ func TestPauseFailsOnWindowsServerContainers(t *testing.T) {
 	client := testEnv.APIClient()
 	ctx := context.Background()
 
-	cID := container.Run(t, ctx, client)
+	cID := container.Run(ctx, t, client)
 	poll.WaitOn(t, container.IsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
 
 	err := client.ContainerPause(ctx, cID)
@@ -71,7 +71,7 @@ func TestPauseStopPausedContainer(t *testing.T) {
 	client := testEnv.APIClient()
 	ctx := context.Background()
 
-	cID := container.Run(t, ctx, client)
+	cID := container.Run(ctx, t, client)
 	poll.WaitOn(t, container.IsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
 
 	err := client.ContainerPause(ctx, cID)

--- a/integration/container/ps_test.go
+++ b/integration/container/ps_test.go
@@ -16,9 +16,9 @@ func TestPsFilter(t *testing.T) {
 	client := testEnv.APIClient()
 	ctx := context.Background()
 
-	prev := container.Create(t, ctx, client)
-	top := container.Create(t, ctx, client)
-	next := container.Create(t, ctx, client)
+	prev := container.Create(ctx, t, client)
+	top := container.Create(ctx, t, client)
+	next := container.Create(ctx, t, client)
 
 	containerIDs := func(containers []types.Container) []string {
 		var entries []string

--- a/integration/container/remove_test.go
+++ b/integration/container/remove_test.go
@@ -36,7 +36,7 @@ func TestRemoveContainerWithRemovedVolume(t *testing.T) {
 	tempDir := fs.NewDir(t, "test-rm-container-with-removed-volume", fs.WithMode(0755))
 	defer tempDir.Remove()
 
-	cID := container.Run(t, ctx, client, container.WithCmd("true"), container.WithBind(tempDir.Path(), prefix+slash+"test"))
+	cID := container.Run(ctx, t, client, container.WithCmd("true"), container.WithBind(tempDir.Path(), prefix+slash+"test"))
 	poll.WaitOn(t, container.IsInState(ctx, client, cID, "exited"), poll.WithDelay(100*time.Millisecond))
 
 	err := os.RemoveAll(tempDir.Path())
@@ -59,7 +59,7 @@ func TestRemoveContainerWithVolume(t *testing.T) {
 
 	prefix, slash := getPrefixAndSlashFromDaemonPlatform()
 
-	cID := container.Run(t, ctx, client, container.WithCmd("true"), container.WithVolume(prefix+slash+"srv"))
+	cID := container.Run(ctx, t, client, container.WithCmd("true"), container.WithVolume(prefix+slash+"srv"))
 	poll.WaitOn(t, container.IsInState(ctx, client, cID, "exited"), poll.WithDelay(100*time.Millisecond))
 
 	insp, _, err := client.ContainerInspectWithRaw(ctx, cID, true)
@@ -82,7 +82,7 @@ func TestRemoveContainerRunning(t *testing.T) {
 	ctx := context.Background()
 	client := testEnv.APIClient()
 
-	cID := container.Run(t, ctx, client)
+	cID := container.Run(ctx, t, client)
 
 	err := client.ContainerRemove(ctx, cID, types.ContainerRemoveOptions{})
 	assert.Check(t, is.ErrorContains(err, "cannot remove a running container"))
@@ -93,7 +93,7 @@ func TestRemoveContainerForceRemoveRunning(t *testing.T) {
 	ctx := context.Background()
 	client := testEnv.APIClient()
 
-	cID := container.Run(t, ctx, client)
+	cID := container.Run(ctx, t, client)
 
 	err := client.ContainerRemove(ctx, cID, types.ContainerRemoveOptions{
 		Force: true,

--- a/integration/container/rename_test.go
+++ b/integration/container/rename_test.go
@@ -30,18 +30,18 @@ func TestRenameLinkedContainer(t *testing.T) {
 
 	aName := "a0" + t.Name()
 	bName := "b0" + t.Name()
-	aID := container.Run(t, ctx, client, container.WithName(aName))
-	bID := container.Run(t, ctx, client, container.WithName(bName), container.WithLinks(aName))
+	aID := container.Run(ctx, t, client, container.WithName(aName))
+	bID := container.Run(ctx, t, client, container.WithName(bName), container.WithLinks(aName))
 
 	err := client.ContainerRename(ctx, aID, "a1"+t.Name())
 	assert.NilError(t, err)
 
-	container.Run(t, ctx, client, container.WithName(aName))
+	container.Run(ctx, t, client, container.WithName(aName))
 
 	err = client.ContainerRemove(ctx, bID, types.ContainerRemoveOptions{Force: true})
 	assert.NilError(t, err)
 
-	bID = container.Run(t, ctx, client, container.WithName(bName), container.WithLinks(aName))
+	bID = container.Run(ctx, t, client, container.WithName(bName), container.WithLinks(aName))
 
 	inspect, err := client.ContainerInspect(ctx, bID)
 	assert.NilError(t, err)
@@ -54,7 +54,7 @@ func TestRenameStoppedContainer(t *testing.T) {
 	client := testEnv.APIClient()
 
 	oldName := "first_name" + t.Name()
-	cID := container.Run(t, ctx, client, container.WithName(oldName), container.WithCmd("sh"))
+	cID := container.Run(ctx, t, client, container.WithName(oldName), container.WithCmd("sh"))
 	poll.WaitOn(t, container.IsInState(ctx, client, cID, "exited"), poll.WithDelay(100*time.Millisecond))
 
 	inspect, err := client.ContainerInspect(ctx, cID)
@@ -76,7 +76,7 @@ func TestRenameRunningContainerAndReuse(t *testing.T) {
 	client := testEnv.APIClient()
 
 	oldName := "first_name" + t.Name()
-	cID := container.Run(t, ctx, client, container.WithName(oldName))
+	cID := container.Run(ctx, t, client, container.WithName(oldName))
 	poll.WaitOn(t, container.IsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
 
 	newName := "new_name" + stringid.GenerateRandomID()
@@ -90,7 +90,7 @@ func TestRenameRunningContainerAndReuse(t *testing.T) {
 	_, err = client.ContainerInspect(ctx, oldName)
 	assert.Check(t, is.ErrorContains(err, "No such container: "+oldName))
 
-	cID = container.Run(t, ctx, client, container.WithName(oldName))
+	cID = container.Run(ctx, t, client, container.WithName(oldName))
 	poll.WaitOn(t, container.IsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
 
 	inspect, err = client.ContainerInspect(ctx, cID)
@@ -104,7 +104,7 @@ func TestRenameInvalidName(t *testing.T) {
 	client := testEnv.APIClient()
 
 	oldName := "first_name" + t.Name()
-	cID := container.Run(t, ctx, client, container.WithName(oldName))
+	cID := container.Run(ctx, t, client, container.WithName(oldName))
 	poll.WaitOn(t, container.IsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
 
 	err := client.ContainerRename(ctx, oldName, "new:invalid")
@@ -132,7 +132,7 @@ func TestRenameAnonymousContainer(t *testing.T) {
 	_, err := client.NetworkCreate(ctx, networkName, types.NetworkCreate{})
 
 	assert.NilError(t, err)
-	cID := container.Run(t, ctx, client, func(c *container.TestContainerConfig) {
+	cID := container.Run(ctx, t, client, func(c *container.TestContainerConfig) {
 		c.NetworkingConfig.EndpointsConfig = map[string]*network.EndpointSettings{
 			networkName: {},
 		}
@@ -155,7 +155,7 @@ func TestRenameAnonymousContainer(t *testing.T) {
 	if testEnv.OSType == "windows" {
 		count = "-n"
 	}
-	cID = container.Run(t, ctx, client, func(c *container.TestContainerConfig) {
+	cID = container.Run(ctx, t, client, func(c *container.TestContainerConfig) {
 		c.NetworkingConfig.EndpointsConfig = map[string]*network.EndpointSettings{
 			networkName: {},
 		}
@@ -175,7 +175,7 @@ func TestRenameContainerWithSameName(t *testing.T) {
 	client := testEnv.APIClient()
 
 	oldName := "old" + t.Name()
-	cID := container.Run(t, ctx, client, container.WithName(oldName))
+	cID := container.Run(ctx, t, client, container.WithName(oldName))
 
 	poll.WaitOn(t, container.IsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
 	err := client.ContainerRename(ctx, oldName, oldName)
@@ -198,12 +198,12 @@ func TestRenameContainerWithLinkedContainer(t *testing.T) {
 	client := testEnv.APIClient()
 
 	db1Name := "db1" + t.Name()
-	db1ID := container.Run(t, ctx, client, container.WithName(db1Name))
+	db1ID := container.Run(ctx, t, client, container.WithName(db1Name))
 	poll.WaitOn(t, container.IsInState(ctx, client, db1ID, "running"), poll.WithDelay(100*time.Millisecond))
 
 	app1Name := "app1" + t.Name()
 	app2Name := "app2" + t.Name()
-	app1ID := container.Run(t, ctx, client, container.WithName(app1Name), container.WithLinks(db1Name+":/mysql"))
+	app1ID := container.Run(ctx, t, client, container.WithName(app1Name), container.WithLinks(db1Name+":/mysql"))
 	poll.WaitOn(t, container.IsInState(ctx, client, app1ID, "running"), poll.WithDelay(100*time.Millisecond))
 
 	err := client.ContainerRename(ctx, app1Name, app2Name)

--- a/integration/container/resize_test.go
+++ b/integration/container/resize_test.go
@@ -22,7 +22,7 @@ func TestResize(t *testing.T) {
 	client := testEnv.APIClient()
 	ctx := context.Background()
 
-	cID := container.Run(t, ctx, client)
+	cID := container.Run(ctx, t, client)
 
 	poll.WaitOn(t, container.IsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
 
@@ -40,7 +40,7 @@ func TestResizeWithInvalidSize(t *testing.T) {
 	client := testEnv.APIClient()
 	ctx := context.Background()
 
-	cID := container.Run(t, ctx, client)
+	cID := container.Run(ctx, t, client)
 
 	poll.WaitOn(t, container.IsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
 
@@ -55,7 +55,7 @@ func TestResizeWhenContainerNotStarted(t *testing.T) {
 	client := testEnv.APIClient()
 	ctx := context.Background()
 
-	cID := container.Run(t, ctx, client, container.WithCmd("echo"))
+	cID := container.Run(ctx, t, client, container.WithCmd("echo"))
 
 	poll.WaitOn(t, container.IsInState(ctx, client, cID, "exited"), poll.WithDelay(100*time.Millisecond))
 

--- a/integration/container/run_linux_test.go
+++ b/integration/container/run_linux_test.go
@@ -29,7 +29,7 @@ func TestKernelTCPMemory(t *testing.T) {
 		kernelMemoryTCP int64 = 200 * 1024 * 1024
 	)
 
-	cID := container.Run(t, ctx, client, func(c *container.TestContainerConfig) {
+	cID := container.Run(ctx, t, client, func(c *container.TestContainerConfig) {
 		c.HostConfig.Resources = containertypes.Resources{
 			KernelMemoryTCP: kernelMemoryTCP,
 		}
@@ -65,7 +65,7 @@ func TestNISDomainname(t *testing.T) {
 		domainname = "baz.cyphar.com"
 	)
 
-	cID := container.Run(t, ctx, client, func(c *container.TestContainerConfig) {
+	cID := container.Run(ctx, t, client, func(c *container.TestContainerConfig) {
 		c.Config.Hostname = hostname
 		c.Config.Domainname = domainname
 	})

--- a/integration/container/stats_test.go
+++ b/integration/container/stats_test.go
@@ -25,7 +25,7 @@ func TestStats(t *testing.T) {
 	info, err := client.Info(ctx)
 	assert.NilError(t, err)
 
-	cID := container.Run(t, ctx, client)
+	cID := container.Run(ctx, t, client)
 
 	poll.WaitOn(t, container.IsInState(ctx, client, cID, "running"), poll.WithDelay(100*time.Millisecond))
 

--- a/integration/container/stop_linux_test.go
+++ b/integration/container/stop_linux_test.go
@@ -54,7 +54,7 @@ func TestStopContainerWithTimeout(t *testing.T) {
 		d := d
 		t.Run(strconv.Itoa(d.timeout), func(t *testing.T) {
 			t.Parallel()
-			id := container.Run(t, ctx, client, testCmd)
+			id := container.Run(ctx, t, client, testCmd)
 
 			timeout := time.Duration(d.timeout) * time.Second
 			err := client.ContainerStop(ctx, id, &timeout)
@@ -78,7 +78,7 @@ func TestDeleteDevicemapper(t *testing.T) {
 	client := testEnv.APIClient()
 	ctx := context.Background()
 
-	id := container.Run(t, ctx, client, container.WithName("foo-"+t.Name()), container.WithCmd("echo"))
+	id := container.Run(ctx, t, client, container.WithName("foo-"+t.Name()), container.WithCmd("echo"))
 
 	poll.WaitOn(t, container.IsStopped(ctx, client, id), poll.WithDelay(100*time.Millisecond))
 

--- a/integration/container/stop_test.go
+++ b/integration/container/stop_test.go
@@ -17,7 +17,7 @@ func TestStopContainerWithRestartPolicyAlways(t *testing.T) {
 
 	names := []string{"verifyRestart1-" + t.Name(), "verifyRestart2-" + t.Name()}
 	for _, name := range names {
-		container.Run(t, ctx, client,
+		container.Run(ctx, t, client,
 			container.WithName(name),
 			container.WithCmd("false"),
 			container.WithRestartPolicy("always"),

--- a/integration/container/stop_windows_test.go
+++ b/integration/container/stop_windows_test.go
@@ -51,7 +51,7 @@ func TestStopContainerWithTimeout(t *testing.T) {
 		d := d
 		t.Run(strconv.Itoa(d.timeout), func(t *testing.T) {
 			t.Parallel()
-			id := container.Run(t, ctx, client, testCmd)
+			id := container.Run(ctx, t, client, testCmd)
 
 			timeout := time.Duration(d.timeout) * time.Second
 			err := client.ContainerStop(ctx, id, &timeout)

--- a/integration/container/update_linux_test.go
+++ b/integration/container/update_linux_test.go
@@ -26,7 +26,7 @@ func TestUpdateMemory(t *testing.T) {
 	client := testEnv.APIClient()
 	ctx := context.Background()
 
-	cID := container.Run(t, ctx, client, func(c *container.TestContainerConfig) {
+	cID := container.Run(ctx, t, client, func(c *container.TestContainerConfig) {
 		c.HostConfig.Resources = containertypes.Resources{
 			Memory: 200 * 1024 * 1024,
 		}
@@ -72,7 +72,7 @@ func TestUpdateCPUQuota(t *testing.T) {
 	client := testEnv.APIClient()
 	ctx := context.Background()
 
-	cID := container.Run(t, ctx, client)
+	cID := container.Run(ctx, t, client)
 
 	for _, test := range []struct {
 		desc   string
@@ -140,7 +140,7 @@ func TestUpdatePidsLimit(t *testing.T) {
 
 		t.Run(test.desc, func(t *testing.T) {
 			// Using "network=host" to speed up creation (13.96s vs 6.54s)
-			cID := container.Run(t, ctx, apiClient, container.WithPidsLimit(test.initial), container.WithNetworkMode("host"))
+			cID := container.Run(ctx, t, apiClient, container.WithPidsLimit(test.initial), container.WithNetworkMode("host"))
 
 			_, err := c.ContainerUpdate(ctx, cID, containertypes.UpdateConfig{
 				Resources: containertypes.Resources{

--- a/integration/container/update_test.go
+++ b/integration/container/update_test.go
@@ -17,7 +17,7 @@ func TestUpdateRestartPolicy(t *testing.T) {
 	client := testEnv.APIClient()
 	ctx := context.Background()
 
-	cID := container.Run(t, ctx, client, container.WithCmd("sh", "-c", "sleep 1 && false"), func(c *container.TestContainerConfig) {
+	cID := container.Run(ctx, t, client, container.WithCmd("sh", "-c", "sleep 1 && false"), func(c *container.TestContainerConfig) {
 		c.HostConfig.RestartPolicy = containertypes.RestartPolicy{
 			Name:              "on-failure",
 			MaximumRetryCount: 3,
@@ -50,7 +50,7 @@ func TestUpdateRestartWithAutoRemove(t *testing.T) {
 	client := testEnv.APIClient()
 	ctx := context.Background()
 
-	cID := container.Run(t, ctx, client, container.WithAutoRemove)
+	cID := container.Run(ctx, t, client, container.WithAutoRemove)
 
 	_, err := client.ContainerUpdate(ctx, cID, containertypes.UpdateConfig{
 		RestartPolicy: containertypes.RestartPolicy{

--- a/integration/container/wait_test.go
+++ b/integration/container/wait_test.go
@@ -39,7 +39,7 @@ func TestWaitNonBlocked(t *testing.T) {
 		t.Run(tc.doc, func(t *testing.T) {
 			t.Parallel()
 			ctx := context.Background()
-			containerID := container.Run(t, ctx, cli, container.WithCmd("sh", "-c", tc.cmd))
+			containerID := container.Run(ctx, t, cli, container.WithCmd("sh", "-c", tc.cmd))
 			poll.WaitOn(t, container.IsInState(ctx, cli, containerID, "exited"), poll.WithTimeout(30*time.Second), poll.WithDelay(100*time.Millisecond))
 
 			waitresC, errC := cli.ContainerWait(ctx, containerID, "")
@@ -81,7 +81,7 @@ func TestWaitBlocked(t *testing.T) {
 		t.Run(tc.doc, func(t *testing.T) {
 			t.Parallel()
 			ctx := context.Background()
-			containerID := container.Run(t, ctx, cli, container.WithCmd("sh", "-c", tc.cmd))
+			containerID := container.Run(ctx, t, cli, container.WithCmd("sh", "-c", tc.cmd))
 			poll.WaitOn(t, container.IsInState(ctx, cli, containerID, "running"), poll.WithTimeout(30*time.Second), poll.WithDelay(100*time.Millisecond))
 
 			waitresC, errC := cli.ContainerWait(ctx, containerID, "")

--- a/integration/image/commit_test.go
+++ b/integration/image/commit_test.go
@@ -19,7 +19,7 @@ func TestCommitInheritsEnv(t *testing.T) {
 	client := testEnv.APIClient()
 	ctx := context.Background()
 
-	cID1 := container.Create(t, ctx, client)
+	cID1 := container.Create(ctx, t, client)
 
 	commitResp1, err := client.ContainerCommit(ctx, cID1, types.ContainerCommitOptions{
 		Changes:   []string{"ENV PATH=/bin"},
@@ -33,7 +33,7 @@ func TestCommitInheritsEnv(t *testing.T) {
 	expectedEnv1 := []string{"PATH=/bin"}
 	assert.Check(t, is.DeepEqual(expectedEnv1, image1.Config.Env))
 
-	cID2 := container.Create(t, ctx, client, container.WithImage(image1.ID))
+	cID2 := container.Create(ctx, t, client, container.WithImage(image1.ID))
 
 	commitResp2, err := client.ContainerCommit(ctx, cID2, types.ContainerCommitOptions{
 		Changes:   []string{"ENV PATH=/usr/bin:$PATH"},

--- a/integration/image/remove_test.go
+++ b/integration/image/remove_test.go
@@ -20,7 +20,7 @@ func TestRemoveImageOrphaning(t *testing.T) {
 	img := "test-container-orphaning"
 
 	// Create a container from busybox, and commit a small change so we have a new image
-	cID1 := container.Create(t, ctx, client, container.WithCmd(""))
+	cID1 := container.Create(ctx, t, client, container.WithCmd(""))
 	commitResp1, err := client.ContainerCommit(ctx, cID1, types.ContainerCommitOptions{
 		Changes:   []string{`ENTRYPOINT ["true"]`},
 		Reference: img,
@@ -33,7 +33,7 @@ func TestRemoveImageOrphaning(t *testing.T) {
 	assert.Check(t, is.Equal(resp.ID, commitResp1.ID))
 
 	// Create a container from created image, and commit a small change with same reference name
-	cID2 := container.Create(t, ctx, client, container.WithImage(img), container.WithCmd(""))
+	cID2 := container.Create(ctx, t, client, container.WithImage(img), container.WithCmd(""))
 	commitResp2, err := client.ContainerCommit(ctx, cID2, types.ContainerCommitOptions{
 		Changes:   []string{`LABEL Maintainer="Integration Tests"`},
 		Reference: img,

--- a/integration/internal/container/container.go
+++ b/integration/internal/container/container.go
@@ -48,8 +48,7 @@ func Create(ctx context.Context, t *testing.T, client client.APIClient, ops ...f
 }
 
 // Run creates and start a container with the specified options
-// nolint: golint
-func Run(t *testing.T, ctx context.Context, client client.APIClient, ops ...func(*TestContainerConfig)) string { // nolint: golint
+func Run(ctx context.Context, t *testing.T, client client.APIClient, ops ...func(*TestContainerConfig)) string {
 	t.Helper()
 	id := Create(ctx, t, client, ops...)
 

--- a/integration/internal/container/container.go
+++ b/integration/internal/container/container.go
@@ -22,8 +22,7 @@ type TestContainerConfig struct {
 }
 
 // Create creates a container with the specified options
-// nolint: golint
-func Create(t *testing.T, ctx context.Context, client client.APIClient, ops ...func(*TestContainerConfig)) string { // nolint: golint
+func Create(ctx context.Context, t *testing.T, client client.APIClient, ops ...func(*TestContainerConfig)) string {
 	t.Helper()
 	cmd := []string{"top"}
 	if runtime.GOOS == "windows" {
@@ -52,7 +51,7 @@ func Create(t *testing.T, ctx context.Context, client client.APIClient, ops ...f
 // nolint: golint
 func Run(t *testing.T, ctx context.Context, client client.APIClient, ops ...func(*TestContainerConfig)) string { // nolint: golint
 	t.Helper()
-	id := Create(t, ctx, client, ops...)
+	id := Create(ctx, t, client, ops...)
 
 	err := client.ContainerStart(ctx, id, types.ContainerStartOptions{})
 	assert.NilError(t, err)

--- a/integration/internal/network/network.go
+++ b/integration/internal/network/network.go
@@ -26,8 +26,7 @@ func Create(ctx context.Context, client client.APIClient, name string, ops ...fu
 }
 
 // CreateNoError creates a network with the specified options and verifies there were no errors
-// nolint: golint
-func CreateNoError(t *testing.T, ctx context.Context, client client.APIClient, name string, ops ...func(*types.NetworkCreate)) string { // nolint: golint
+func CreateNoError(ctx context.Context, t *testing.T, client client.APIClient, name string, ops ...func(*types.NetworkCreate)) string { // nolint: golint
 	t.Helper()
 
 	name, err := createNetwork(ctx, client, name, ops...)

--- a/integration/network/delete_test.go
+++ b/integration/network/delete_test.go
@@ -27,7 +27,7 @@ func containsNetwork(nws []types.NetworkResource, networkID string) bool {
 // first network's ID as name.
 //
 // After successful creation, properties of all three networks is returned
-func createAmbiguousNetworks(t *testing.T, ctx context.Context, client dclient.APIClient) (string, string, string) { // nolint: golint
+func createAmbiguousNetworks(ctx context.Context, t *testing.T, client dclient.APIClient) (string, string, string) {
 	testNet := network.CreateNoError(ctx, t, client, "testNet")
 	idPrefixNet := network.CreateNoError(ctx, t, client, testNet[:12])
 	fullIDNet := network.CreateNoError(ctx, t, client, testNet)
@@ -70,7 +70,7 @@ func TestDockerNetworkDeletePreferID(t *testing.T) {
 	defer setupTest(t)()
 	client := testEnv.APIClient()
 	ctx := context.Background()
-	testNet, idPrefixNet, fullIDNet := createAmbiguousNetworks(t, ctx, client)
+	testNet, idPrefixNet, fullIDNet := createAmbiguousNetworks(ctx, t, client)
 
 	// Delete the network using a prefix of the first network's ID as name.
 	// This should the network name with the id-prefix, not the original network.

--- a/integration/network/delete_test.go
+++ b/integration/network/delete_test.go
@@ -28,9 +28,9 @@ func containsNetwork(nws []types.NetworkResource, networkID string) bool {
 //
 // After successful creation, properties of all three networks is returned
 func createAmbiguousNetworks(t *testing.T, ctx context.Context, client dclient.APIClient) (string, string, string) { // nolint: golint
-	testNet := network.CreateNoError(t, ctx, client, "testNet")
-	idPrefixNet := network.CreateNoError(t, ctx, client, testNet[:12])
-	fullIDNet := network.CreateNoError(t, ctx, client, testNet)
+	testNet := network.CreateNoError(ctx, t, client, "testNet")
+	idPrefixNet := network.CreateNoError(ctx, t, client, testNet[:12])
+	fullIDNet := network.CreateNoError(ctx, t, client, testNet)
 
 	nws, err := client.NetworkList(ctx, types.NetworkListOptions{})
 	assert.NilError(t, err)
@@ -49,7 +49,7 @@ func TestNetworkCreateDelete(t *testing.T) {
 	ctx := context.Background()
 
 	netName := "testnetwork_" + t.Name()
-	network.CreateNoError(t, ctx, client, netName,
+	network.CreateNoError(ctx, t, client, netName,
 		network.WithCheckDuplicate(),
 	)
 	assert.Check(t, IsNetworkAvailable(client, netName))

--- a/integration/network/inspect_test.go
+++ b/integration/network/inspect_test.go
@@ -21,7 +21,7 @@ func TestInspectNetwork(t *testing.T) {
 	defer c.Close()
 
 	networkName := "Overlay" + t.Name()
-	overlayID := network.CreateNoError(t, context.Background(), c, networkName,
+	overlayID := network.CreateNoError(context.Background(), t, c, networkName,
 		network.WithDriver("overlay"),
 		network.WithCheckDuplicate(),
 	)

--- a/integration/network/ipvlan/ipvlan_test.go
+++ b/integration/network/ipvlan/ipvlan_test.go
@@ -153,8 +153,8 @@ func testIpvlanL2NilParent(client dclient.APIClient) func(*testing.T) {
 		assert.Check(t, n.IsNetworkAvailable(client, netName))
 
 		ctx := context.Background()
-		id1 := container.Run(t, ctx, client, container.WithNetworkMode(netName))
-		id2 := container.Run(t, ctx, client, container.WithNetworkMode(netName))
+		id1 := container.Run(ctx, t, client, container.WithNetworkMode(netName))
+		id2 := container.Run(ctx, t, client, container.WithNetworkMode(netName))
 
 		_, err := container.Exec(ctx, client, id2, []string{"ping", "-c", "1", id1})
 		assert.NilError(t, err)
@@ -171,8 +171,8 @@ func testIpvlanL2InternalMode(client dclient.APIClient) func(*testing.T) {
 		assert.Check(t, n.IsNetworkAvailable(client, netName))
 
 		ctx := context.Background()
-		id1 := container.Run(t, ctx, client, container.WithNetworkMode(netName))
-		id2 := container.Run(t, ctx, client, container.WithNetworkMode(netName))
+		id1 := container.Run(ctx, t, client, container.WithNetworkMode(netName))
+		id2 := container.Run(ctx, t, client, container.WithNetworkMode(netName))
 
 		timeoutCtx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 		defer cancel()
@@ -197,11 +197,11 @@ func testIpvlanL3NilParent(client dclient.APIClient) func(*testing.T) {
 		assert.Check(t, n.IsNetworkAvailable(client, netName))
 
 		ctx := context.Background()
-		id1 := container.Run(t, ctx, client,
+		id1 := container.Run(ctx, t, client,
 			container.WithNetworkMode(netName),
 			container.WithIPv4(netName, "172.28.220.10"),
 		)
-		id2 := container.Run(t, ctx, client,
+		id2 := container.Run(ctx, t, client,
 			container.WithNetworkMode(netName),
 			container.WithIPv4(netName, "172.28.230.10"),
 		)
@@ -223,11 +223,11 @@ func testIpvlanL3InternalMode(client dclient.APIClient) func(*testing.T) {
 		assert.Check(t, n.IsNetworkAvailable(client, netName))
 
 		ctx := context.Background()
-		id1 := container.Run(t, ctx, client,
+		id1 := container.Run(ctx, t, client,
 			container.WithNetworkMode(netName),
 			container.WithIPv4(netName, "172.28.220.10"),
 		)
-		id2 := container.Run(t, ctx, client,
+		id2 := container.Run(ctx, t, client,
 			container.WithNetworkMode(netName),
 			container.WithIPv4(netName, "172.28.230.10"),
 		)
@@ -259,12 +259,12 @@ func testIpvlanL2MultiSubnet(client dclient.APIClient) func(*testing.T) {
 
 		// start dual stack containers and verify the user specified --ip and --ip6 addresses on subnets 172.28.100.0/24 and 2001:db8:abc2::/64
 		ctx := context.Background()
-		id1 := container.Run(t, ctx, client,
+		id1 := container.Run(ctx, t, client,
 			container.WithNetworkMode(netName),
 			container.WithIPv4(netName, "172.28.200.20"),
 			container.WithIPv6(netName, "2001:db8:abc8::20"),
 		)
-		id2 := container.Run(t, ctx, client,
+		id2 := container.Run(ctx, t, client,
 			container.WithNetworkMode(netName),
 			container.WithIPv4(netName, "172.28.200.21"),
 			container.WithIPv6(netName, "2001:db8:abc8::21"),
@@ -280,12 +280,12 @@ func testIpvlanL2MultiSubnet(client dclient.APIClient) func(*testing.T) {
 		assert.NilError(t, err)
 
 		// start dual stack containers and verify the user specified --ip and --ip6 addresses on subnets 172.28.102.0/24 and 2001:db8:abc4::/64
-		id3 := container.Run(t, ctx, client,
+		id3 := container.Run(ctx, t, client,
 			container.WithNetworkMode(netName),
 			container.WithIPv4(netName, "172.28.202.20"),
 			container.WithIPv6(netName, "2001:db8:abc6::20"),
 		)
-		id4 := container.Run(t, ctx, client,
+		id4 := container.Run(ctx, t, client,
 			container.WithNetworkMode(netName),
 			container.WithIPv4(netName, "172.28.202.21"),
 			container.WithIPv6(netName, "2001:db8:abc6::21"),
@@ -326,12 +326,12 @@ func testIpvlanL3MultiSubnet(client dclient.APIClient) func(*testing.T) {
 
 		// start dual stack containers and verify the user specified --ip and --ip6 addresses on subnets 172.28.100.0/24 and 2001:db8:abc2::/64
 		ctx := context.Background()
-		id1 := container.Run(t, ctx, client,
+		id1 := container.Run(ctx, t, client,
 			container.WithNetworkMode(netName),
 			container.WithIPv4(netName, "172.28.10.20"),
 			container.WithIPv6(netName, "2001:db8:abc9::20"),
 		)
-		id2 := container.Run(t, ctx, client,
+		id2 := container.Run(ctx, t, client,
 			container.WithNetworkMode(netName),
 			container.WithIPv4(netName, "172.28.10.21"),
 			container.WithIPv6(netName, "2001:db8:abc9::21"),
@@ -347,12 +347,12 @@ func testIpvlanL3MultiSubnet(client dclient.APIClient) func(*testing.T) {
 		assert.NilError(t, err)
 
 		// start dual stack containers and verify the user specified --ip and --ip6 addresses on subnets 172.28.102.0/24 and 2001:db8:abc4::/64
-		id3 := container.Run(t, ctx, client,
+		id3 := container.Run(ctx, t, client,
 			container.WithNetworkMode(netName),
 			container.WithIPv4(netName, "172.28.12.20"),
 			container.WithIPv6(netName, "2001:db8:abc7::20"),
 		)
-		id4 := container.Run(t, ctx, client,
+		id4 := container.Run(ctx, t, client,
 			container.WithNetworkMode(netName),
 			container.WithIPv4(netName, "172.28.12.21"),
 			container.WithIPv6(netName, "2001:db8:abc7::21"),
@@ -392,7 +392,7 @@ func testIpvlanAddressing(client dclient.APIClient) func(*testing.T) {
 		assert.Check(t, n.IsNetworkAvailable(client, netNameL2))
 
 		ctx := context.Background()
-		id1 := container.Run(t, ctx, client,
+		id1 := container.Run(ctx, t, client,
 			container.WithNetworkMode(netNameL2),
 		)
 		// Validate ipvlan l2 mode defaults gateway sets the default IPAM next-hop inferred from the subnet
@@ -414,7 +414,7 @@ func testIpvlanAddressing(client dclient.APIClient) func(*testing.T) {
 		)
 		assert.Check(t, n.IsNetworkAvailable(client, netNameL3))
 
-		id2 := container.Run(t, ctx, client,
+		id2 := container.Run(ctx, t, client,
 			container.WithNetworkMode(netNameL3),
 		)
 		// Validate ipvlan l3 mode sets the v4 gateway to dev eth0 and disregards any explicit or inferred next-hops

--- a/integration/network/ipvlan/ipvlan_test.go
+++ b/integration/network/ipvlan/ipvlan_test.go
@@ -39,7 +39,7 @@ func TestDockerNetworkIpvlanPersistance(t *testing.T) {
 
 	// create a network specifying the desired sub-interface name
 	netName := "di-persist"
-	net.CreateNoError(t, context.Background(), c, netName,
+	net.CreateNoError(context.Background(), t, c, netName,
 		net.WithIPvlan("di-dummy0.70", ""),
 	)
 
@@ -105,7 +105,7 @@ func testIpvlanSubinterface(client dclient.APIClient) func(*testing.T) {
 		defer n.DeleteInterface(t, master)
 
 		netName := "di-subinterface"
-		net.CreateNoError(t, context.Background(), client, netName,
+		net.CreateNoError(context.Background(), t, client, netName,
 			net.WithIPvlan("di-dummy0.60", ""),
 		)
 		assert.Check(t, n.IsNetworkAvailable(client, netName))
@@ -130,7 +130,7 @@ func testIpvlanOverlapParent(client dclient.APIClient) func(*testing.T) {
 		n.CreateVlanInterface(t, master, parent, "30")
 
 		netName := "di-subinterface"
-		net.CreateNoError(t, context.Background(), client, netName,
+		net.CreateNoError(context.Background(), t, client, netName,
 			net.WithIPvlan(parent, ""),
 		)
 		assert.Check(t, n.IsNetworkAvailable(client, netName))
@@ -147,7 +147,7 @@ func testIpvlanL2NilParent(client dclient.APIClient) func(*testing.T) {
 	return func(t *testing.T) {
 		// ipvlan l2 mode - dummy parent interface is provisioned dynamically
 		netName := "di-nil-parent"
-		net.CreateNoError(t, context.Background(), client, netName,
+		net.CreateNoError(context.Background(), t, client, netName,
 			net.WithIPvlan("", ""),
 		)
 		assert.Check(t, n.IsNetworkAvailable(client, netName))
@@ -164,7 +164,7 @@ func testIpvlanL2NilParent(client dclient.APIClient) func(*testing.T) {
 func testIpvlanL2InternalMode(client dclient.APIClient) func(*testing.T) {
 	return func(t *testing.T) {
 		netName := "di-internal"
-		net.CreateNoError(t, context.Background(), client, netName,
+		net.CreateNoError(context.Background(), t, client, netName,
 			net.WithIPvlan("", ""),
 			net.WithInternal(),
 		)
@@ -189,7 +189,7 @@ func testIpvlanL2InternalMode(client dclient.APIClient) func(*testing.T) {
 func testIpvlanL3NilParent(client dclient.APIClient) func(*testing.T) {
 	return func(t *testing.T) {
 		netName := "di-nil-parent-l3"
-		net.CreateNoError(t, context.Background(), client, netName,
+		net.CreateNoError(context.Background(), t, client, netName,
 			net.WithIPvlan("", "l3"),
 			net.WithIPAM("172.28.230.0/24", ""),
 			net.WithIPAM("172.28.220.0/24", ""),
@@ -214,7 +214,7 @@ func testIpvlanL3NilParent(client dclient.APIClient) func(*testing.T) {
 func testIpvlanL3InternalMode(client dclient.APIClient) func(*testing.T) {
 	return func(t *testing.T) {
 		netName := "di-internal-l3"
-		net.CreateNoError(t, context.Background(), client, netName,
+		net.CreateNoError(context.Background(), t, client, netName,
 			net.WithIPvlan("", "l3"),
 			net.WithInternal(),
 			net.WithIPAM("172.28.230.0/24", ""),
@@ -247,7 +247,7 @@ func testIpvlanL3InternalMode(client dclient.APIClient) func(*testing.T) {
 func testIpvlanL2MultiSubnet(client dclient.APIClient) func(*testing.T) {
 	return func(t *testing.T) {
 		netName := "dualstackl2"
-		net.CreateNoError(t, context.Background(), client, netName,
+		net.CreateNoError(context.Background(), t, client, netName,
 			net.WithIPvlan("", ""),
 			net.WithIPv6(),
 			net.WithIPAM("172.28.200.0/24", ""),
@@ -314,7 +314,7 @@ func testIpvlanL2MultiSubnet(client dclient.APIClient) func(*testing.T) {
 func testIpvlanL3MultiSubnet(client dclient.APIClient) func(*testing.T) {
 	return func(t *testing.T) {
 		netName := "dualstackl3"
-		net.CreateNoError(t, context.Background(), client, netName,
+		net.CreateNoError(context.Background(), t, client, netName,
 			net.WithIPvlan("", "l3"),
 			net.WithIPv6(),
 			net.WithIPAM("172.28.10.0/24", ""),
@@ -383,7 +383,7 @@ func testIpvlanAddressing(client dclient.APIClient) func(*testing.T) {
 		// Verify ipvlan l2 mode sets the proper default gateway routes via netlink
 		// for either an explicitly set route by the user or inferred via default IPAM
 		netNameL2 := "dualstackl2"
-		net.CreateNoError(t, context.Background(), client, netNameL2,
+		net.CreateNoError(context.Background(), t, client, netNameL2,
 			net.WithIPvlan("", "l2"),
 			net.WithIPv6(),
 			net.WithIPAM("172.28.140.0/24", "172.28.140.254"),
@@ -406,7 +406,7 @@ func testIpvlanAddressing(client dclient.APIClient) func(*testing.T) {
 
 		// Validate ipvlan l3 mode sets the v4 gateway to dev eth0 and disregards any explicit or inferred next-hops
 		netNameL3 := "dualstackl3"
-		net.CreateNoError(t, context.Background(), client, netNameL3,
+		net.CreateNoError(context.Background(), t, client, netNameL3,
 			net.WithIPvlan("", "l3"),
 			net.WithIPv6(),
 			net.WithIPAM("172.28.160.0/24", "172.28.160.254"),

--- a/integration/network/macvlan/macvlan_test.go
+++ b/integration/network/macvlan/macvlan_test.go
@@ -33,7 +33,7 @@ func TestDockerNetworkMacvlanPersistance(t *testing.T) {
 	c := d.NewClientT(t)
 
 	netName := "dm-persist"
-	net.CreateNoError(t, context.Background(), c, netName,
+	net.CreateNoError(context.Background(), t, c, netName,
 		net.WithMacvlan("dm-dummy0.60"),
 	)
 	assert.Check(t, n.IsNetworkAvailable(c, netName))
@@ -86,7 +86,7 @@ func testMacvlanOverlapParent(client client.APIClient) func(*testing.T) {
 
 		netName := "dm-subinterface"
 		parentName := "dm-dummy0.40"
-		net.CreateNoError(t, context.Background(), client, netName,
+		net.CreateNoError(context.Background(), t, client, netName,
 			net.WithMacvlan(parentName),
 		)
 		assert.Check(t, n.IsNetworkAvailable(client, netName))
@@ -116,7 +116,7 @@ func testMacvlanSubinterface(client client.APIClient) func(*testing.T) {
 		n.CreateVlanInterface(t, master, parentName, "20")
 
 		netName := "dm-subinterface"
-		net.CreateNoError(t, context.Background(), client, netName,
+		net.CreateNoError(context.Background(), t, client, netName,
 			net.WithMacvlan(parentName),
 		)
 		assert.Check(t, n.IsNetworkAvailable(client, netName))
@@ -135,7 +135,7 @@ func testMacvlanNilParent(client client.APIClient) func(*testing.T) {
 	return func(t *testing.T) {
 		// macvlan bridge mode - dummy parent interface is provisioned dynamically
 		netName := "dm-nil-parent"
-		net.CreateNoError(t, context.Background(), client, netName,
+		net.CreateNoError(context.Background(), t, client, netName,
 			net.WithMacvlan(""),
 		)
 		assert.Check(t, n.IsNetworkAvailable(client, netName))
@@ -153,7 +153,7 @@ func testMacvlanInternalMode(client client.APIClient) func(*testing.T) {
 	return func(t *testing.T) {
 		// macvlan bridge mode - dummy parent interface is provisioned dynamically
 		netName := "dm-internal"
-		net.CreateNoError(t, context.Background(), client, netName,
+		net.CreateNoError(context.Background(), t, client, netName,
 			net.WithMacvlan(""),
 			net.WithInternal(),
 		)
@@ -178,7 +178,7 @@ func testMacvlanInternalMode(client client.APIClient) func(*testing.T) {
 func testMacvlanMultiSubnet(client client.APIClient) func(*testing.T) {
 	return func(t *testing.T) {
 		netName := "dualstackbridge"
-		net.CreateNoError(t, context.Background(), client, netName,
+		net.CreateNoError(context.Background(), t, client, netName,
 			net.WithMacvlan(""),
 			net.WithIPv6(),
 			net.WithIPAM("172.28.100.0/24", ""),
@@ -247,7 +247,7 @@ func testMacvlanAddressing(client client.APIClient) func(*testing.T) {
 	return func(t *testing.T) {
 		// Ensure the default gateways, next-hops and default dev devices are properly set
 		netName := "dualstackbridge"
-		net.CreateNoError(t, context.Background(), client, netName,
+		net.CreateNoError(context.Background(), t, client, netName,
 			net.WithMacvlan(""),
 			net.WithIPv6(),
 			net.WithOption("macvlan_mode", "bridge"),

--- a/integration/network/macvlan/macvlan_test.go
+++ b/integration/network/macvlan/macvlan_test.go
@@ -141,8 +141,8 @@ func testMacvlanNilParent(client client.APIClient) func(*testing.T) {
 		assert.Check(t, n.IsNetworkAvailable(client, netName))
 
 		ctx := context.Background()
-		id1 := container.Run(t, ctx, client, container.WithNetworkMode(netName))
-		id2 := container.Run(t, ctx, client, container.WithNetworkMode(netName))
+		id1 := container.Run(ctx, t, client, container.WithNetworkMode(netName))
+		id2 := container.Run(ctx, t, client, container.WithNetworkMode(netName))
 
 		_, err := container.Exec(ctx, client, id2, []string{"ping", "-c", "1", id1})
 		assert.Check(t, err == nil)
@@ -160,8 +160,8 @@ func testMacvlanInternalMode(client client.APIClient) func(*testing.T) {
 		assert.Check(t, n.IsNetworkAvailable(client, netName))
 
 		ctx := context.Background()
-		id1 := container.Run(t, ctx, client, container.WithNetworkMode(netName))
-		id2 := container.Run(t, ctx, client, container.WithNetworkMode(netName))
+		id1 := container.Run(ctx, t, client, container.WithNetworkMode(netName))
+		id2 := container.Run(ctx, t, client, container.WithNetworkMode(netName))
 
 		timeoutCtx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 		defer cancel()
@@ -191,12 +191,12 @@ func testMacvlanMultiSubnet(client client.APIClient) func(*testing.T) {
 
 		// start dual stack containers and verify the user specified --ip and --ip6 addresses on subnets 172.28.100.0/24 and 2001:db8:abc2::/64
 		ctx := context.Background()
-		id1 := container.Run(t, ctx, client,
+		id1 := container.Run(ctx, t, client,
 			container.WithNetworkMode("dualstackbridge"),
 			container.WithIPv4("dualstackbridge", "172.28.100.20"),
 			container.WithIPv6("dualstackbridge", "2001:db8:abc2::20"),
 		)
-		id2 := container.Run(t, ctx, client,
+		id2 := container.Run(ctx, t, client,
 			container.WithNetworkMode("dualstackbridge"),
 			container.WithIPv4("dualstackbridge", "172.28.100.21"),
 			container.WithIPv6("dualstackbridge", "2001:db8:abc2::21"),
@@ -212,12 +212,12 @@ func testMacvlanMultiSubnet(client client.APIClient) func(*testing.T) {
 		assert.NilError(t, err)
 
 		// start dual stack containers and verify the user specified --ip and --ip6 addresses on subnets 172.28.102.0/24 and 2001:db8:abc4::/64
-		id3 := container.Run(t, ctx, client,
+		id3 := container.Run(ctx, t, client,
 			container.WithNetworkMode("dualstackbridge"),
 			container.WithIPv4("dualstackbridge", "172.28.102.20"),
 			container.WithIPv6("dualstackbridge", "2001:db8:abc4::20"),
 		)
-		id4 := container.Run(t, ctx, client,
+		id4 := container.Run(ctx, t, client,
 			container.WithNetworkMode("dualstackbridge"),
 			container.WithIPv4("dualstackbridge", "172.28.102.21"),
 			container.WithIPv6("dualstackbridge", "2001:db8:abc4::21"),
@@ -257,7 +257,7 @@ func testMacvlanAddressing(client client.APIClient) func(*testing.T) {
 		assert.Check(t, n.IsNetworkAvailable(client, netName))
 
 		ctx := context.Background()
-		id1 := container.Run(t, ctx, client,
+		id1 := container.Run(ctx, t, client,
 			container.WithNetworkMode("dualstackbridge"),
 		)
 

--- a/integration/network/network_test.go
+++ b/integration/network/network_test.go
@@ -29,14 +29,14 @@ func TestRunContainerWithBridgeNone(t *testing.T) {
 	c := d.NewClientT(t)
 	ctx := context.Background()
 
-	id1 := container.Run(t, ctx, c)
+	id1 := container.Run(ctx, t, c)
 	defer c.ContainerRemove(ctx, id1, types.ContainerRemoveOptions{Force: true})
 
 	result, err := container.Exec(ctx, c, id1, []string{"ip", "l"})
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(false, strings.Contains(result.Combined(), "eth0")), "There shouldn't be eth0 in container in default(bridge) mode when bridge network is disabled")
 
-	id2 := container.Run(t, ctx, c, container.WithNetworkMode("bridge"))
+	id2 := container.Run(ctx, t, c, container.WithNetworkMode("bridge"))
 	defer c.ContainerRemove(ctx, id2, types.ContainerRemoveOptions{Force: true})
 
 	result, err = container.Exec(ctx, c, id2, []string{"ip", "l"})
@@ -50,7 +50,7 @@ func TestRunContainerWithBridgeNone(t *testing.T) {
 	err = cmd.Run()
 	assert.NilError(t, err, "Failed to get current process network namespace: %+v", err)
 
-	id3 := container.Run(t, ctx, c, container.WithNetworkMode("host"))
+	id3 := container.Run(ctx, t, c, container.WithNetworkMode("host"))
 	defer c.ContainerRemove(ctx, id3, types.ContainerRemoveOptions{Force: true})
 
 	result, err = container.Exec(ctx, c, id3, []string{"sh", "-c", nsCommand})

--- a/integration/network/service_test.go
+++ b/integration/network/service_test.go
@@ -71,7 +71,7 @@ func TestDaemonDefaultNetworkPools(t *testing.T) {
 
 	// Create a bridge network and verify its subnet is the second default pool
 	name := "elango" + t.Name()
-	network.CreateNoError(t, context.Background(), c, name,
+	network.CreateNoError(context.Background(), t, c, name,
 		network.WithDriver("bridge"),
 	)
 	out, err = c.NetworkInspect(context.Background(), name, types.NetworkInspectOptions{})
@@ -80,7 +80,7 @@ func TestDaemonDefaultNetworkPools(t *testing.T) {
 
 	// Create a bridge network and verify its subnet is the third default pool
 	name = "saanvi" + t.Name()
-	network.CreateNoError(t, context.Background(), c, name,
+	network.CreateNoError(context.Background(), t, c, name,
 		network.WithDriver("bridge"),
 	)
 	out, err = c.NetworkInspect(context.Background(), name, types.NetworkInspectOptions{})
@@ -103,7 +103,7 @@ func TestDaemonRestartWithExistingNetwork(t *testing.T) {
 
 	// Create a bridge network
 	name := "elango" + t.Name()
-	network.CreateNoError(t, context.Background(), c, name,
+	network.CreateNoError(context.Background(), t, c, name,
 		network.WithDriver("bridge"),
 	)
 
@@ -136,7 +136,7 @@ func TestDaemonRestartWithExistingNetworkWithDefaultPoolRange(t *testing.T) {
 
 	// Create a bridge network
 	name := "elango" + t.Name()
-	network.CreateNoError(t, context.Background(), c, name,
+	network.CreateNoError(context.Background(), t, c, name,
 		network.WithDriver("bridge"),
 	)
 
@@ -147,7 +147,7 @@ func TestDaemonRestartWithExistingNetworkWithDefaultPoolRange(t *testing.T) {
 
 	// Create a bridge network
 	name = "sthira" + t.Name()
-	network.CreateNoError(t, context.Background(), c, name,
+	network.CreateNoError(context.Background(), t, c, name,
 		network.WithDriver("bridge"),
 	)
 	out, err = c.NetworkInspect(context.Background(), name, types.NetworkInspectOptions{})
@@ -162,7 +162,7 @@ func TestDaemonRestartWithExistingNetworkWithDefaultPoolRange(t *testing.T) {
 
 	// Create a bridge network
 	name = "saanvi" + t.Name()
-	network.CreateNoError(t, context.Background(), c, name,
+	network.CreateNoError(context.Background(), t, c, name,
 		network.WithDriver("bridge"),
 	)
 	out1, err := c.NetworkInspect(context.Background(), name, types.NetworkInspectOptions{})
@@ -343,7 +343,7 @@ func TestServiceWithDataPathPortInit(t *testing.T) {
 
 	// Create a overlay network
 	name := "saanvisthira" + t.Name()
-	network.CreateNoError(t, context.Background(), c, name,
+	network.CreateNoError(context.Background(), t, c, name,
 		network.WithDriver("overlay"))
 
 	var instances uint64 = 1
@@ -369,7 +369,7 @@ func TestServiceWithDataPathPortInit(t *testing.T) {
 
 	// Create a overlay network
 	name = "saanvisthira" + t.Name()
-	network.CreateNoError(t, context.Background(), c, name,
+	network.CreateNoError(context.Background(), t, c, name,
 		network.WithDriver("overlay"))
 
 	serviceID = swarm.CreateService(t, d,
@@ -402,7 +402,7 @@ func TestServiceWithDefaultAddressPoolInit(t *testing.T) {
 
 	// Create a overlay network
 	name := "saanvisthira" + t.Name()
-	network.CreateNoError(t, context.Background(), cli, name,
+	network.CreateNoError(context.Background(), t, cli, name,
 		network.WithDriver("overlay"))
 
 	var instances uint64 = 1

--- a/integration/plugin/authz/authz_plugin_test.go
+++ b/integration/plugin/authz/authz_plugin_test.go
@@ -92,7 +92,7 @@ func TestAuthZPluginAllowRequest(t *testing.T) {
 	ctx := context.Background()
 
 	// Ensure command successful
-	cID := container.Run(t, ctx, c)
+	cID := container.Run(ctx, t, c)
 
 	assertURIRecorded(t, ctrl.requestsURIs, "/containers/create")
 	assertURIRecorded(t, ctrl.requestsURIs, fmt.Sprintf("/containers/%s/start", cID))
@@ -224,7 +224,7 @@ func TestAuthZPluginAllowEventStream(t *testing.T) {
 	defer cancel()
 
 	// Create a container and wait for the creation events
-	cID := container.Run(t, ctx, c)
+	cID := container.Run(ctx, t, c)
 	poll.WaitOn(t, container.IsInState(ctx, c, cID, "running"))
 
 	created := false
@@ -348,7 +348,7 @@ func TestAuthZPluginEnsureLoadImportWorking(t *testing.T) {
 
 	exportedImagePath := filepath.Join(tmp, "export.tar")
 
-	cID := container.Run(t, ctx, c)
+	cID := container.Run(ctx, t, c)
 
 	responseReader, err := c.ContainerExport(context.Background(), cID)
 	assert.NilError(t, err)
@@ -388,7 +388,7 @@ func TestAuthzPluginEnsureContainerCopyToFrom(t *testing.T) {
 	c := d.NewClientT(t)
 	ctx := context.Background()
 
-	cID := container.Run(t, ctx, c)
+	cID := container.Run(ctx, t, c)
 	defer c.ContainerRemove(ctx, cID, types.ContainerRemoveOptions{Force: true})
 
 	_, err = f.Seek(0, io.SeekStart)

--- a/integration/plugin/authz/authz_plugin_v2_test.go
+++ b/integration/plugin/authz/authz_plugin_v2_test.go
@@ -55,7 +55,7 @@ func TestAuthZPluginV2AllowNonVolumeRequest(t *testing.T) {
 	d.LoadBusybox(t)
 
 	// Ensure docker run command and accompanying docker ps are successful
-	cID := container.Run(t, ctx, c)
+	cID := container.Run(ctx, t, c)
 
 	_, err = c.ContainerInspect(ctx, cID)
 	assert.NilError(t, err)

--- a/integration/plugin/graphdriver/external_test.go
+++ b/integration/plugin/graphdriver/external_test.go
@@ -399,7 +399,7 @@ func testGraphDriverPull(c client.APIClient, d *daemon.Daemon) func(*testing.T) 
 		_, err = io.Copy(ioutil.Discard, r)
 		assert.NilError(t, err)
 
-		container.Run(t, ctx, c, container.WithImage("busybox:latest@sha256:bbc3a03235220b170ba48a157dd097dd1379299370e1ed99ce976df0355d24f0"))
+		container.Run(ctx, t, c, container.WithImage("busybox:latest@sha256:bbc3a03235220b170ba48a157dd097dd1379299370e1ed99ce976df0355d24f0"))
 	}
 }
 
@@ -439,7 +439,7 @@ func TestGraphdriverPluginV2(t *testing.T) {
 
 // nolint: golint
 func testGraphDriver(t *testing.T, c client.APIClient, ctx context.Context, driverName string, afterContainerRunFn func(*testing.T)) { //nolint: golint
-	id := container.Run(t, ctx, c, container.WithCmd("sh", "-c", "echo hello > /hello"))
+	id := container.Run(ctx, t, c, container.WithCmd("sh", "-c", "echo hello > /hello"))
 
 	if afterContainerRunFn != nil {
 		afterContainerRunFn(t)

--- a/integration/plugin/graphdriver/external_test.go
+++ b/integration/plugin/graphdriver/external_test.go
@@ -360,7 +360,7 @@ func testExternalGraphDriver(ext string, ec map[string]*graphEventsCounter) func
 
 			ctx := context.Background()
 
-			testGraphDriver(t, c, ctx, driverName, func(t *testing.T) {
+			testGraphDriver(ctx, t, c, driverName, func(t *testing.T) {
 				d.Restart(t, "-s", driverName)
 			})
 
@@ -434,11 +434,10 @@ func TestGraphdriverPluginV2(t *testing.T) {
 	d.Stop(t)
 	d.StartWithBusybox(t, "-s", plugin, "--storage-opt", "overlay2.override_kernel_check=1")
 
-	testGraphDriver(t, client, ctx, plugin, nil)
+	testGraphDriver(ctx, t, client, plugin, nil)
 }
 
-// nolint: golint
-func testGraphDriver(t *testing.T, c client.APIClient, ctx context.Context, driverName string, afterContainerRunFn func(*testing.T)) { //nolint: golint
+func testGraphDriver(ctx context.Context, t *testing.T, c client.APIClient, driverName string, afterContainerRunFn func(*testing.T)) {
 	id := container.Run(ctx, t, c, container.WithCmd("sh", "-c", "echo hello > /hello"))
 
 	if afterContainerRunFn != nil {

--- a/integration/plugin/logging/logging_linux_test.go
+++ b/integration/plugin/logging/logging_linux_test.go
@@ -33,7 +33,7 @@ func TestContinueAfterPluginCrash(t *testing.T) {
 
 	ctx, cancel = context.WithTimeout(context.Background(), 60*time.Second)
 
-	id := container.Run(t, ctx, client,
+	id := container.Run(ctx, t, client,
 		container.WithAutoRemove,
 		container.WithLogDriver("test"),
 		container.WithCmd(

--- a/integration/service/create_test.go
+++ b/integration/service/create_test.go
@@ -84,7 +84,7 @@ func TestCreateServiceMultipleTimes(t *testing.T) {
 	ctx := context.Background()
 
 	overlayName := "overlay1_" + t.Name()
-	overlayID := network.CreateNoError(t, ctx, client, overlayName,
+	overlayID := network.CreateNoError(ctx, t, client, overlayName,
 		network.WithCheckDuplicate(),
 		network.WithDriver("overlay"),
 	)
@@ -175,11 +175,11 @@ func TestCreateWithDuplicateNetworkNames(t *testing.T) {
 	ctx := context.Background()
 
 	name := "foo_" + t.Name()
-	n1 := network.CreateNoError(t, ctx, client, name, network.WithDriver("bridge"))
-	n2 := network.CreateNoError(t, ctx, client, name, network.WithDriver("bridge"))
+	n1 := network.CreateNoError(ctx, t, client, name, network.WithDriver("bridge"))
+	n2 := network.CreateNoError(ctx, t, client, name, network.WithDriver("bridge"))
 
 	// Duplicates with name but with different driver
-	n3 := network.CreateNoError(t, ctx, client, name, network.WithDriver("overlay"))
+	n3 := network.CreateNoError(ctx, t, client, name, network.WithDriver("overlay"))
 
 	// Create Service with the same name
 	var instances uint64 = 1

--- a/integration/service/network_test.go
+++ b/integration/service/network_test.go
@@ -24,7 +24,7 @@ func TestDockerNetworkConnectAlias(t *testing.T) {
 	ctx := context.Background()
 
 	name := t.Name() + "test-alias"
-	net.CreateNoError(t, ctx, client, name,
+	net.CreateNoError(ctx, t, client, name,
 		net.WithDriver("overlay"),
 		net.WithAttachable(),
 	)

--- a/integration/service/network_test.go
+++ b/integration/service/network_test.go
@@ -29,7 +29,7 @@ func TestDockerNetworkConnectAlias(t *testing.T) {
 		net.WithAttachable(),
 	)
 
-	cID1 := container.Create(t, ctx, client, func(c *container.TestContainerConfig) {
+	cID1 := container.Create(ctx, t, client, func(c *container.TestContainerConfig) {
 		c.NetworkingConfig = &network.NetworkingConfig{
 			EndpointsConfig: map[string]*network.EndpointSettings{
 				name: {},
@@ -52,7 +52,7 @@ func TestDockerNetworkConnectAlias(t *testing.T) {
 	assert.Check(t, is.Equal(len(ng1.NetworkSettings.Networks[name].Aliases), 2))
 	assert.Check(t, is.Equal(ng1.NetworkSettings.Networks[name].Aliases[0], "aaa"))
 
-	cID2 := container.Create(t, ctx, client, func(c *container.TestContainerConfig) {
+	cID2 := container.Create(ctx, t, client, func(c *container.TestContainerConfig) {
 		c.NetworkingConfig = &network.NetworkingConfig{
 			EndpointsConfig: map[string]*network.EndpointSettings{
 				name: {},

--- a/integration/service/network_test.go
+++ b/integration/service/network_test.go
@@ -86,12 +86,12 @@ func TestDockerNetworkReConnect(t *testing.T) {
 	ctx := context.Background()
 
 	name := t.Name() + "dummyNet"
-	net.CreateNoError(t, ctx, client, name,
+	net.CreateNoError(ctx, t, client, name,
 		net.WithDriver("overlay"),
 		net.WithAttachable(),
 	)
 
-	c1 := container.Create(t, ctx, client, func(c *container.TestContainerConfig) {
+	c1 := container.Create(ctx, t, client, func(c *container.TestContainerConfig) {
 		c.NetworkingConfig = &network.NetworkingConfig{
 			EndpointsConfig: map[string]*network.EndpointSettings{
 				name: {},

--- a/integration/service/update_test.go
+++ b/integration/service/update_test.go
@@ -207,7 +207,7 @@ func TestServiceUpdateNetwork(t *testing.T) {
 
 	// Create a overlay network
 	testNet := "testNet" + t.Name()
-	overlayID := network.CreateNoError(t, ctx, cli, testNet,
+	overlayID := network.CreateNoError(ctx, t, cli, testNet,
 		network.WithDriver("overlay"))
 
 	var instances uint64 = 1

--- a/integration/system/cgroupdriver_systemd_test.go
+++ b/integration/system/cgroupdriver_systemd_test.go
@@ -41,7 +41,7 @@ func TestCgroupDriverSystemdMemoryLimit(t *testing.T) {
 	const mem = 64 * 1024 * 1024 // 64 MB
 
 	ctx := context.Background()
-	ctrID := container.Create(t, ctx, c, func(ctr *container.TestContainerConfig) {
+	ctrID := container.Create(ctx, t, c, func(ctr *container.TestContainerConfig) {
 		ctr.HostConfig.Resources.Memory = mem
 	})
 	defer c.ContainerRemove(ctx, ctrID, types.ContainerRemoveOptions{Force: true})

--- a/integration/system/event_test.go
+++ b/integration/system/event_test.go
@@ -83,7 +83,7 @@ func TestEventsBackwardsCompatible(t *testing.T) {
 	since := request.DaemonTime(ctx, t, client, testEnv)
 	ts := strconv.FormatInt(since.Unix(), 10)
 
-	cID := container.Create(t, ctx, client)
+	cID := container.Create(ctx, t, client)
 
 	// In case there is no events, the API should have responded immediately (not blocking),
 	// The test here makes sure the response time is less than 3 sec.

--- a/integration/system/event_test.go
+++ b/integration/system/event_test.go
@@ -30,7 +30,7 @@ func TestEventsExecDie(t *testing.T) {
 	ctx := context.Background()
 	client := testEnv.APIClient()
 
-	cID := container.Run(t, ctx, client)
+	cID := container.Run(ctx, t, client)
 
 	id, err := client.ContainerExecCreate(ctx, cID,
 		types.ExecConfig{

--- a/integration/volume/volume_test.go
+++ b/integration/volume/volume_test.go
@@ -68,7 +68,7 @@ func TestVolumesRemove(t *testing.T) {
 
 	prefix, slash := getPrefixAndSlashFromDaemonPlatform()
 
-	id := container.Create(t, ctx, client, container.WithVolume(prefix+slash+"foo"))
+	id := container.Create(ctx, t, client, container.WithVolume(prefix+slash+"foo"))
 
 	c, err := client.ContainerInspect(ctx, id)
 	assert.NilError(t, err)


### PR DESCRIPTION
~**Built on top of https://github.com/docker/engine/pull/279 ("[19.03 backport] Handle the error case when a container reattaches to the same network")** first two commits are from that PR~


backports of:

- https://github.com/moby/moby/pull/39332 Integration: change signatures to fix golint warnings
- https://github.com/moby/moby/pull/39359 integration: get tests to compile again

Some conflicts in test files when backporting the first PR (https://github.com/moby/moby/pull/39332);

- conflict in first commit, due to https://github.com/moby/moby/pull/39204 ("Add alias for hostname if hostname != container name") not being in 19.03 (thus a test missing that was being modified)
- conflict in second commit,  due to https://github.com/moby/moby/pull/38377 (Start containers in their own cgroup namespaces) feature not being in 19.03;

    ```
    Unmerged paths:
      (use "git add/rm <file>..." as appropriate to mark resolution)

    	deleted by us:   integration/container/run_cgroupns_linux_test.go
    	both modified:   integration/internal/container/container.go
    ```
- conflict in third commit (due to the same feature missing);

    ```
    Unmerged paths:
      (use "git add/rm <file>..." as appropriate to mark resolution)

    	deleted by us:   integration/container/run_cgroupns_linux_test.go
    	both modified:   integration/container/run_linux_test.go
    	both modified:   integration/internal/container/container.go
    ```

Conflicts were not too difficult to resolve
 