### PR TITLE
[19.03 backport] Bump Golang 1.12.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@
 
 ARG CROSS="false"
 
-FROM golang:1.12.5 AS base
+FROM golang:1.12.6 AS base
 # allow replacing httpredir or deb mirror
 ARG APT_MIRROR=deb.debian.org
 RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@
 
 ARG CROSS="false"
 
-FROM golang:1.12.6 AS base
+FROM golang:1.12.7 AS base
 # allow replacing httpredir or deb mirror
 ARG APT_MIRROR=deb.debian.org
 RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -1,4 +1,4 @@
-FROM golang:1.12.6-alpine as base
+FROM golang:1.12.7-alpine as base
 
 RUN apk --no-cache add \
     bash \

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -1,4 +1,4 @@
-FROM golang:1.12.5-alpine as base
+FROM golang:1.12.6-alpine as base
 
 RUN apk --no-cache add \
     bash \

--- a/Dockerfile.simple
+++ b/Dockerfile.simple
@@ -5,7 +5,7 @@
 
 # This represents the bare minimum required to build and test Docker.
 
-FROM golang:1.12.6
+FROM golang:1.12.7
 
 # allow replacing httpredir or deb mirror
 ARG APT_MIRROR=deb.debian.org

--- a/Dockerfile.simple
+++ b/Dockerfile.simple
@@ -5,7 +5,7 @@
 
 # This represents the bare minimum required to build and test Docker.
 
-FROM golang:1.12.5
+FROM golang:1.12.6
 
 # allow replacing httpredir or deb mirror
 ARG APT_MIRROR=deb.debian.org

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -168,7 +168,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 # Environment variable notes:
 #  - GO_VERSION must be consistent with 'Dockerfile' used by Linux.
 #  - FROM_DOCKERFILE is used for detection of building within a container.
-ENV GO_VERSION=1.12.6 `
+ENV GO_VERSION=1.12.7 `
     GIT_VERSION=2.11.1 `
     GOPATH=C:\go `
     FROM_DOCKERFILE=1

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -168,7 +168,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 # Environment variable notes:
 #  - GO_VERSION must be consistent with 'Dockerfile' used by Linux.
 #  - FROM_DOCKERFILE is used for detection of building within a container.
-ENV GO_VERSION=1.12.5 `
+ENV GO_VERSION=1.12.6 `
     GIT_VERSION=2.11.1 `
     GOPATH=C:\go `
     FROM_DOCKERFILE=1


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/39355 and https://github.com/moby/moby/pull/39474 for 19.03

go1.12.6 (released 2019/06/11) includes fixes to the compiler, the linker,
the go command, and the <code>crypto/x509</code>, <code>net/http</code>, and
<code>os</code> packages. See the<a href="https://github.com/golang/go/issues?q=milestone%3AGo1.12.6">Go 1.12.6 milestone</a> on our issue tracker for details.

https://github.com/golang/go/compare/go1.12.5...go1.12.6


go1.12.7 (released 2019/07/08) includes fixes to cgo, the compiler, and the
linker. See the Go 1.12.7 milestone on our issue tracker for details:
https://github.com/golang/go/issues?q=milestone%3AGo1.12.7

full diff: https://github.com/golang/go/compare/go1.12.6...go1.12.7
