### PR TITLE
[18.09 backport] Fix docker cp when container source path is /

### DIFF
--- a/integration/container/copy_test.go
+++ b/integration/container/copy_test.go
@@ -1,13 +1,20 @@
 package container // import "github.com/docker/docker/integration/container"
 
 import (
+	"archive/tar"
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/integration/internal/container"
+	"github.com/docker/docker/internal/test/fakecontext"
+	"github.com/docker/docker/pkg/jsonmessage"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
 	"gotest.tools/skip"
@@ -63,4 +70,79 @@ func TestCopyToContainerPathIsNotDir(t *testing.T) {
 
 	err := apiclient.CopyToContainer(ctx, cid, "/etc/passwd/", nil, types.CopyToContainerOptions{})
 	assert.Assert(t, is.ErrorContains(err, "not a directory"))
+}
+
+func TestCopyFromContainerRoot(t *testing.T) {
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
+	defer setupTest(t)()
+
+	ctx := context.Background()
+	apiClient := testEnv.APIClient()
+
+	dir, err := ioutil.TempDir("", t.Name())
+	assert.NilError(t, err)
+	defer os.RemoveAll(dir)
+
+	buildCtx := fakecontext.New(t, dir, fakecontext.WithFile("foo", "hello"), fakecontext.WithFile("baz", "world"), fakecontext.WithDockerfile(`
+		FROM scratch
+		COPY foo /foo
+		COPY baz /bar/baz
+		CMD /fake
+	`))
+	defer buildCtx.Close()
+
+	resp, err := apiClient.ImageBuild(ctx, buildCtx.AsTarReader(t), types.ImageBuildOptions{})
+	assert.NilError(t, err)
+	defer resp.Body.Close()
+
+	var imageID string
+	err = jsonmessage.DisplayJSONMessagesStream(resp.Body, ioutil.Discard, 0, false, func(msg jsonmessage.JSONMessage) {
+		var r types.BuildResult
+		assert.NilError(t, json.Unmarshal(*msg.Aux, &r))
+		imageID = r.ID
+	})
+	assert.NilError(t, err)
+	assert.Assert(t, imageID != "")
+
+	cid := container.Create(ctx, t, apiClient, container.WithImage(imageID))
+
+	rdr, _, err := apiClient.CopyFromContainer(ctx, cid, "/")
+	assert.NilError(t, err)
+	defer rdr.Close()
+
+	tr := tar.NewReader(rdr)
+	expect := map[string]string{
+		"/foo":     "hello",
+		"/bar/baz": "world",
+	}
+	found := make(map[string]bool, 2)
+	var numFound int
+	for {
+		h, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		assert.NilError(t, err)
+
+		expected, exists := expect[h.Name]
+		if !exists {
+			// this archive will have extra stuff in it since we are copying from root
+			// and docker adds a bunch of stuff
+			continue
+		}
+
+		numFound++
+		found[h.Name] = true
+
+		buf, err := ioutil.ReadAll(tr)
+		assert.NilError(t, err)
+		assert.Check(t, is.Equal(string(buf), expected))
+
+		if numFound == len(expect) {
+			break
+		}
+	}
+
+	assert.Check(t, found["/foo"], "/foo file not found in archive")
+	assert.Check(t, found["/bar/baz"], "/bar/baz file not found in archive")
 }

--- a/integration/container/copy_test.go
+++ b/integration/container/copy_test.go
@@ -105,7 +105,7 @@ func TestCopyFromContainer(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Assert(t, imageID != "")
 
-	cid := container.Create(ctx, t, apiClient, container.WithImage(imageID))
+	cid := container.Create(t, ctx, apiClient, container.WithImage(imageID))
 
 	for _, x := range []struct {
 		src    string

--- a/pkg/archive/archive_unix.go
+++ b/pkg/archive/archive_unix.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"syscall"
 
 	"github.com/docker/docker/pkg/idtools"
@@ -26,7 +27,7 @@ func fixVolumePathPrefix(srcPath string) string {
 // can't use filepath.Join(srcPath,include) because this will clean away
 // a trailing "." or "/" which may be important.
 func getWalkRoot(srcPath string, include string) string {
-	return srcPath + string(filepath.Separator) + include
+	return strings.TrimSuffix(srcPath, string(filepath.Separator)) + string(filepath.Separator) + include
 }
 
 // CanonicalTarNameForPath returns platform-specific filepath


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/39357 for 18.09


Another attempt at fixing https://github.com/moby/moby/issues/39348
Fixes https://github.com/moby/moby/issues/39348
Previous attempt at https://github.com/moby/moby/pull/39351

Before 7a7357d, archive.TarResourceRebase was being used to copy files
and folders from the container. That function splits the source path
into a dirname + basename pair to support copying a file:
if you wanted to tar `dir/file` it would tar from `dir` the file `file`
(as part of the IncludedFiles option).

However, that path splitting logic was kept for folders as well, which
resulted in weird inputs to archive.TarWithOptions:
if you wanted to tar `dir1/dir2` it would tar from `dir1` the directory
`dir2` (as part of IncludedFiles option).

Although it was weird, it worked fine until we started chrooting into
the container rootfs when doing a `docker cp` with container source set
to `/` (cf 3029e76 (https://github.com/moby/moby/pull/39292)).

The fix is to only do the path splitting logic if the source is a file.

Unfortunately, 7a7357d added support for LCOW by duplicating some of
this subtle logic. Ideally we would need to do more refactoring of the
archive codebase to properly encapsulate these behaviors behind well-
documented APIs.

This fix does not do that. Instead, it fixes the issue inline.

Signed-off-by: Tibor Vass <tibor@docker.com>


I added a couple of more tests than the actual issue needs, just to make sure there are no other regressions compared to before the cve fix (3029e76).

Huge thanks to @cpuguy83 ❤️who worked tirelessly with me to understand the code and make this PR.