### PR TITLE
[19.03 backport] Add realChroot for non linux/windows

### DIFF
--- a/pkg/chrootarchive/chroot_unix.go
+++ b/pkg/chrootarchive/chroot_unix.go
@@ -10,3 +10,7 @@ func chroot(path string) error {
 	}
 	return unix.Chdir("/")
 }
+
+func realChroot(path string) error {
+	return chroot(path)
+}


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/39462

3029e765e241ea2b5249868705dbf9095bc4d529 (https://github.com/moby/moby/pull/39292) broke compilation on
non-Linux/Windows systems.
This change fixes that.

Fixes https://github.com/moby/moby/issues/39437