### PR TITLE
[18.09] bump libnetwork 55685ba49593e67f5e1c8180539379b16736c25e (18.09 branch)

### DIFF
--- a/hack/dockerfile/install/proxy.installer
+++ b/hack/dockerfile/install/proxy.installer
@@ -3,7 +3,7 @@
 # LIBNETWORK_COMMIT is used to build the docker-userland-proxy binary. When
 # updating the binary version, consider updating github.com/docker/libnetwork
 # in vendor.conf accordingly
-LIBNETWORK_COMMIT=e7933d41e7b206756115aa9df5e0599fc5169742 # bump_18.09 branch
+LIBNETWORK_COMMIT=55685ba49593e67f5e1c8180539379b16736c25e # bump_18.09 branch
 
 install_proxy() {
 	case "$1" in

--- a/vendor.conf
+++ b/vendor.conf
@@ -37,7 +37,7 @@ github.com/mitchellh/hashstructure 2bca23e0e452137f789efbc8610126fd8b94f73b
 #get libnetwork packages
 
 # When updating, also update LIBNETWORK_COMMIT in hack/dockerfile/install/proxy accordingly
-github.com/docker/libnetwork e7933d41e7b206756115aa9df5e0599fc5169742 # bump_18.09 branch
+github.com/docker/libnetwork 55685ba49593e67f5e1c8180539379b16736c25e # bump_18.09 branch
 github.com/docker/go-events 9461782956ad83b30282bf90e31fa6a70c255ba9
 github.com/armon/go-radix e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec

--- a/vendor/github.com/docker/libnetwork/controller.go
+++ b/vendor/github.com/docker/libnetwork/controller.go
@@ -339,7 +339,6 @@ func (c *controller) clusterAgentInit() {
 				}
 			}
 		case cluster.EventNodeLeave:
-			keysAvailable = false
 			c.agentOperationStart()
 			c.Lock()
 			c.keys = nil
@@ -706,11 +705,17 @@ const overlayDSROptionString = "dsr"
 // NewNetwork creates a new network of the specified network type. The options
 // are network specific and modeled in a generic way.
 func (c *controller) NewNetwork(networkType, name string, id string, options ...NetworkOption) (Network, error) {
+	var (
+		cap *driverapi.Capability
+		err error
+		t   *network
+	)
+
 	if id != "" {
 		c.networkLocker.Lock(id)
 		defer c.networkLocker.Unlock(id)
 
-		if _, err := c.NetworkByID(id); err == nil {
+		if _, err = c.NetworkByID(id); err == nil {
 			return nil, NetworkNameError(id)
 		}
 	}
@@ -739,14 +744,9 @@ func (c *controller) NewNetwork(networkType, name string, id string, options ...
 	}
 
 	network.processOptions(options...)
-	if err := network.validateConfiguration(); err != nil {
+	if err = network.validateConfiguration(); err != nil {
 		return nil, err
 	}
-
-	var (
-		cap *driverapi.Capability
-		err error
-	)
 
 	// Reset network types, force local scope and skip allocation and
 	// plumbing for configuration networks. Reset of the config-only
@@ -794,11 +794,11 @@ func (c *controller) NewNetwork(networkType, name string, id string, options ...
 	// From this point on, we need the network specific configuration,
 	// which may come from a configuration-only network
 	if network.configFrom != "" {
-		t, err := c.getConfigNetwork(network.configFrom)
+		t, err = c.getConfigNetwork(network.configFrom)
 		if err != nil {
 			return nil, types.NotFoundErrorf("configuration network %q does not exist", network.configFrom)
 		}
-		if err := t.applyConfigurationTo(network); err != nil {
+		if err = t.applyConfigurationTo(network); err != nil {
 			return nil, types.InternalErrorf("Failed to apply configuration: %v", err)
 		}
 		defer func() {

--- a/vendor/github.com/docker/libnetwork/drivers/bridge/setup_ip_tables.go
+++ b/vendor/github.com/docker/libnetwork/drivers/bridge/setup_ip_tables.go
@@ -302,7 +302,7 @@ func setINC(iface string, enable bool) error {
 				if i == 1 {
 					// Rollback the rule installed on first chain
 					if err2 := iptables.ProgramRule(iptables.Filter, chains[0], iptables.Delete, rules[0]); err2 != nil {
-						logrus.Warn("Failed to rollback iptables rule after failure (%v): %v", err, err2)
+						logrus.Warnf("Failed to rollback iptables rule after failure (%v): %v", err, err2)
 					}
 				}
 				return fmt.Errorf(msg)

--- a/vendor/github.com/docker/libnetwork/drivers/overlay/ostweaks_linux.go
+++ b/vendor/github.com/docker/libnetwork/drivers/overlay/ostweaks_linux.go
@@ -7,9 +7,9 @@ import (
 )
 
 var ovConfig = map[string]*kernel.OSValue{
-	"net.ipv4.neigh.default.gc_thresh1": {"8192", checkHigher},
-	"net.ipv4.neigh.default.gc_thresh2": {"49152", checkHigher},
-	"net.ipv4.neigh.default.gc_thresh3": {"65536", checkHigher},
+	"net.ipv4.neigh.default.gc_thresh1": {Value: "8192", CheckFn: checkHigher},
+	"net.ipv4.neigh.default.gc_thresh2": {Value: "49152", CheckFn: checkHigher},
+	"net.ipv4.neigh.default.gc_thresh3": {Value: "65536", CheckFn: checkHigher},
 }
 
 func checkHigher(val1, val2 string) bool {

--- a/vendor/github.com/docker/libnetwork/drivers/windows/windows.go
+++ b/vendor/github.com/docker/libnetwork/drivers/windows/windows.go
@@ -433,7 +433,7 @@ func convertQosPolicies(qosPolicies []types.QosPolicy) ([]json.RawMessage, error
 	// understood by the HCS.
 	for _, elem := range qosPolicies {
 		encodedPolicy, err := json.Marshal(hcsshim.QosPolicy{
-			Type: "QOS",
+			Type:                            "QOS",
 			MaximumOutgoingBandwidthInBytes: elem.MaxEgressBandwidth,
 		})
 

--- a/vendor/github.com/docker/libnetwork/network.go
+++ b/vendor/github.com/docker/libnetwork/network.go
@@ -1054,7 +1054,7 @@ func (n *network) delete(force bool, rmLBEndpoint bool) error {
 					t.Name(), n.Name(), err)
 			}
 		} else {
-			logrus.Warnf("Could not find configuration network %q during removal of network %q", n.configOnly, n.Name())
+			logrus.Warnf("Could not find configuration network %q during removal of network %q", n.configFrom, n.Name())
 		}
 	}
 

--- a/vendor/github.com/docker/libnetwork/osl/namespace_linux.go
+++ b/vendor/github.com/docker/libnetwork/osl/namespace_linux.go
@@ -40,7 +40,7 @@ var (
 	loadBalancerConfig = map[string]*kernel.OSValue{
 		// expires connection from the IPVS connection table when the backend is not available
 		// more info: https://github.com/torvalds/linux/blob/master/Documentation/networking/ipvs-sysctl.txt#L126:1
-		"net.ipv4.vs.expire_nodest_conn": {"1", nil},
+		"net.ipv4.vs.expire_nodest_conn": {Value: "1", CheckFn: nil},
 	}
 )
 

--- a/vendor/github.com/docker/libnetwork/resolver_unix.go
+++ b/vendor/github.com/docker/libnetwork/resolver_unix.go
@@ -76,7 +76,7 @@ func reexecSetupResolver() {
 
 	for _, rule := range rules {
 		if iptables.RawCombinedOutputNative(rule...) != nil {
-			logrus.Errorf("setting up rule failed, %v", rule)
+			logrus.Errorf("set up rule failed, %v", rule)
 		}
 	}
 }

--- a/vendor/github.com/docker/libnetwork/service_linux.go
+++ b/vendor/github.com/docker/libnetwork/service_linux.go
@@ -135,8 +135,7 @@ func (n *network) addLBBackend(ip net.IP, lb *loadBalancer) {
 			if ep := sb.getGatewayEndpoint(); ep != nil {
 				gwIP = ep.Iface().Address().IP
 			}
-			filteredPorts := filterPortConfigs(lb.service.ingressPorts, false)
-			if err := programIngress(gwIP, filteredPorts, false); err != nil {
+			if err := programIngress(gwIP, lb.service.ingressPorts, false); err != nil {
 				logrus.Errorf("Failed to add ingress: %v", err)
 				return
 			}
@@ -233,8 +232,7 @@ func (n *network) rmLBBackend(ip net.IP, lb *loadBalancer, rmService bool, fullR
 			if ep := sb.getGatewayEndpoint(); ep != nil {
 				gwIP = ep.Iface().Address().IP
 			}
-			filteredPorts := filterPortConfigs(lb.service.ingressPorts, true)
-			if err := programIngress(gwIP, filteredPorts, true); err != nil {
+			if err := programIngress(gwIP, lb.service.ingressPorts, true); err != nil {
 				logrus.Errorf("Failed to delete ingress: %v", err)
 			}
 		}
@@ -305,8 +303,10 @@ func filterPortConfigs(ingressPorts []*PortConfig, isDelete bool) []*PortConfig 
 
 func programIngress(gwIP net.IP, ingressPorts []*PortConfig, isDelete bool) error {
 	addDelOpt := "-I"
+	rollbackAddDelOpt := "-D"
 	if isDelete {
 		addDelOpt = "-D"
+		rollbackAddDelOpt = "-I"
 	}
 
 	ingressMu.Lock()
@@ -387,18 +387,35 @@ func programIngress(gwIP net.IP, ingressPorts []*PortConfig, isDelete bool) erro
 		}
 	}
 
-	for _, iPort := range ingressPorts {
+	//Filter the ingress ports until port rules start to be added/deleted
+	filteredPorts := filterPortConfigs(ingressPorts, isDelete)
+	rollbackRules := make([][]string, 0, len(filteredPorts)*3)
+	var portErr error
+	defer func() {
+		if portErr != nil && !isDelete {
+			filterPortConfigs(filteredPorts, !isDelete)
+			for _, rule := range rollbackRules {
+				if err := iptables.RawCombinedOutput(rule...); err != nil {
+					logrus.Warnf("roll back rule failed, %v: %v", rule, err)
+				}
+			}
+		}
+	}()
+
+	for _, iPort := range filteredPorts {
 		if iptables.ExistChain(ingressChain, iptables.Nat) {
 			rule := strings.Fields(fmt.Sprintf("-t nat %s %s -p %s --dport %d -j DNAT --to-destination %s:%d",
 				addDelOpt, ingressChain, strings.ToLower(PortConfig_Protocol_name[int32(iPort.Protocol)]), iPort.PublishedPort, gwIP, iPort.PublishedPort))
-			if err := iptables.RawCombinedOutput(rule...); err != nil {
-				errStr := fmt.Sprintf("setting up rule failed, %v: %v", rule, err)
+			if portErr = iptables.RawCombinedOutput(rule...); portErr != nil {
+				errStr := fmt.Sprintf("set up rule failed, %v: %v", rule, portErr)
 				if !isDelete {
 					return fmt.Errorf("%s", errStr)
 				}
-
 				logrus.Infof("%s", errStr)
 			}
+			rollbackRule := strings.Fields(fmt.Sprintf("-t nat %s %s -p %s --dport %d -j DNAT --to-destination %s:%d", rollbackAddDelOpt,
+				ingressChain, strings.ToLower(PortConfig_Protocol_name[int32(iPort.Protocol)]), iPort.PublishedPort, gwIP, iPort.PublishedPort))
+			rollbackRules = append(rollbackRules, rollbackRule)
 		}
 
 		// Filter table rules to allow a published service to be accessible in the local node from..
@@ -406,24 +423,29 @@ func programIngress(gwIP net.IP, ingressPorts []*PortConfig, isDelete bool) erro
 		// 2) unmanaged containers on bridge networks
 		rule := strings.Fields(fmt.Sprintf("%s %s -m state -p %s --sport %d --state ESTABLISHED,RELATED -j ACCEPT",
 			addDelOpt, ingressChain, strings.ToLower(PortConfig_Protocol_name[int32(iPort.Protocol)]), iPort.PublishedPort))
-		if err := iptables.RawCombinedOutput(rule...); err != nil {
-			errStr := fmt.Sprintf("setting up rule failed, %v: %v", rule, err)
+		if portErr = iptables.RawCombinedOutput(rule...); portErr != nil {
+			errStr := fmt.Sprintf("set up rule failed, %v: %v", rule, portErr)
 			if !isDelete {
 				return fmt.Errorf("%s", errStr)
 			}
 			logrus.Warnf("%s", errStr)
 		}
+		rollbackRule := strings.Fields(fmt.Sprintf("%s %s -m state -p %s --sport %d --state ESTABLISHED,RELATED -j ACCEPT", rollbackAddDelOpt,
+			ingressChain, strings.ToLower(PortConfig_Protocol_name[int32(iPort.Protocol)]), iPort.PublishedPort))
+		rollbackRules = append(rollbackRules, rollbackRule)
 
 		rule = strings.Fields(fmt.Sprintf("%s %s -p %s --dport %d -j ACCEPT",
 			addDelOpt, ingressChain, strings.ToLower(PortConfig_Protocol_name[int32(iPort.Protocol)]), iPort.PublishedPort))
-		if err := iptables.RawCombinedOutput(rule...); err != nil {
-			errStr := fmt.Sprintf("setting up rule failed, %v: %v", rule, err)
+		if portErr = iptables.RawCombinedOutput(rule...); portErr != nil {
+			errStr := fmt.Sprintf("set up rule failed, %v: %v", rule, portErr)
 			if !isDelete {
 				return fmt.Errorf("%s", errStr)
 			}
-
 			logrus.Warnf("%s", errStr)
 		}
+		rollbackRule = strings.Fields(fmt.Sprintf("%s %s -p %s --dport %d -j ACCEPT", rollbackAddDelOpt,
+			ingressChain, strings.ToLower(PortConfig_Protocol_name[int32(iPort.Protocol)]), iPort.PublishedPort))
+		rollbackRules = append(rollbackRules, rollbackRule)
 
 		if err := plumbProxy(iPort, isDelete); err != nil {
 			logrus.Warnf("failed to create proxy for port %d: %v", iPort.PublishedPort, err)
@@ -655,7 +677,7 @@ func fwMarker() {
 
 	for _, rule := range rules {
 		if err := iptables.RawCombinedOutputNative(rule...); err != nil {
-			logrus.Errorf("setting up rule failed, %v: %v", rule, err)
+			logrus.Errorf("set up rule failed, %v: %v", rule, err)
 			os.Exit(8)
 		}
 	}
@@ -742,7 +764,7 @@ func redirector() {
 
 	for _, rule := range rules {
 		if err := iptables.RawCombinedOutputNative(rule...); err != nil {
-			logrus.Errorf("setting up rule failed, %v: %v", rule, err)
+			logrus.Errorf("set up rule failed, %v: %v", rule, err)
 			os.Exit(6)
 		}
 	}
@@ -759,14 +781,14 @@ func redirector() {
 	} {
 		if !iptables.ExistsNative(iptables.Filter, "INPUT", rule...) {
 			if err := iptables.RawCombinedOutputNative(append([]string{"-A", "INPUT"}, rule...)...); err != nil {
-				logrus.Errorf("setting up rule failed, %v: %v", rule, err)
+				logrus.Errorf("set up rule failed, %v: %v", rule, err)
 				os.Exit(7)
 			}
 		}
 		rule[0] = "-s"
 		if !iptables.ExistsNative(iptables.Filter, "OUTPUT", rule...) {
 			if err := iptables.RawCombinedOutputNative(append([]string{"-A", "OUTPUT"}, rule...)...); err != nil {
-				logrus.Errorf("setting up rule failed, %v: %v", rule, err)
+				logrus.Errorf("set up rule failed, %v: %v", rule, err)
 				os.Exit(8)
 			}
 		}

--- a/vendor/github.com/docker/libnetwork/vendor.conf
+++ b/vendor/github.com/docker/libnetwork/vendor.conf
@@ -1,51 +1,50 @@
-github.com/Azure/go-ansiterm d6e3b3328b783f23731bc4d058875b0371ff8109
-github.com/BurntSushi/toml a368813c5e648fee92e5f6c30e3944ff9d5e8895
-github.com/Microsoft/go-winio v0.4.7
-github.com/Microsoft/hcsshim v0.6.11
-github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec
-github.com/armon/go-radix e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
-github.com/boltdb/bolt fff57c100f4dea1905678da7e90d92429dff2904
-github.com/codegangsta/cli a65b733b303f0055f8d324d805f393cd3e7a7904
-github.com/containerd/continuity d3c23511c1bf5851696cba83143d9cbcd666869b
-github.com/coreos/etcd v3.2.1
-github.com/coreos/go-semver v0.2.0
-github.com/deckarep/golang-set ef32fa3046d9f249d399f98ebaf9be944430fd1d
+github.com/Azure/go-ansiterm            d6e3b3328b783f23731bc4d058875b0371ff8109
+github.com/BurntSushi/toml              a368813c5e648fee92e5f6c30e3944ff9d5e8895
+github.com/Microsoft/go-winio           97e4973ce50b2ff5f09635a57e2b88a037aae829 # v0.4.11
+github.com/Microsoft/hcsshim            5b3eff572681588b6ce3df295d3d23b72f053f32 # v0.7.12
+github.com/armon/go-metrics             eb0af217e5e9747e41dd5303755356b62d28e3ec
+github.com/armon/go-radix               e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
+github.com/codegangsta/cli              a65b733b303f0055f8d324d805f393cd3e7a7904
+github.com/containerd/continuity        004b46473808b3e7a4a3049c20e4376c91eb966d
+github.com/coreos/etcd                  61fc123e7a8b14a0a258aa3f5c4159861b1ec2e7 # v3.2.1
+github.com/coreos/go-semver             8ab6407b697782a06568d4b7f1db25550ec2e4c6 # v0.2.0
+github.com/deckarep/golang-set          ef32fa3046d9f249d399f98ebaf9be944430fd1d
+go.etcd.io/bbolt                        7ee3ded59d4835e10f3e7d0f7603c42aa5e83820 # v1.3.1-etcd.8
 
-github.com/docker/docker 162ba6016def672690ee4a1f3978368853a1e149
-github.com/docker/go-connections 7beb39f0b969b075d1325fecb092faf27fd357b6
-github.com/docker/go-events 9461782956ad83b30282bf90e31fa6a70c255ba9
-github.com/docker/go-units 9e638d38cf6977a37a8ea0078f3ee75a7cdb2dd1
-github.com/docker/libkv 1d8431073ae03cdaedb198a89722f3aab6d418ef
+github.com/docker/docker                1046c6371132875d80f287950bb9e9e5cefa8a85 https://github.com/docker/engine.git # 18.09 branch
+github.com/docker/go-connections        7395e3f8aa162843a74ed6d48e79627d9792ac55 # v0.4.0
+github.com/docker/go-events             9461782956ad83b30282bf90e31fa6a70c255ba9
+github.com/docker/go-units              47565b4f722fb6ceae66b95f853feed578a4a51c # v0.3.3
+github.com/docker/libkv                 458977154600b9f23984d9f4b82e79570b5ae12b
 
-github.com/godbus/dbus v4.0.0
-github.com/gogo/protobuf v1.0.0
-github.com/gorilla/context v1.1
-github.com/gorilla/mux v1.1
-github.com/hashicorp/consul v0.5.2
-github.com/hashicorp/go-msgpack 71c2886f5a673a35f909803f38ece5810165097b
-github.com/hashicorp/go-multierror fcdddc395df1ddf4247c69bd436e84cfa0733f7e
-github.com/hashicorp/memberlist 3d8438da9589e7b608a83ffac1ef8211486bcb7c
-github.com/sean-/seed e2103e2c35297fb7e17febb81e49b312087a2372
-github.com/hashicorp/go-sockaddr 6d291a969b86c4b633730bfc6b8b9d64c3aafed9
-github.com/hashicorp/serf 598c54895cc5a7b1a24a398d635e8c0ea0959870
-github.com/mattn/go-shellwords v1.0.3
-github.com/miekg/dns v1.0.7
-github.com/opencontainers/go-digest v1.0.0-rc1
-github.com/opencontainers/image-spec v1.0.1
-github.com/opencontainers/runc 96ec2177ae841256168fcf76954f7177af9446eb
-github.com/opencontainers/runtime-spec v1.0.1
-github.com/samuel/go-zookeeper d0e0d8e11f318e000a8cc434616d69e329edc374
-github.com/sirupsen/logrus v1.0.3
-github.com/syndtr/gocapability 33e07d32887e1e06b7c025f27ce52f62c7990bc0
-github.com/ugorji/go f1f1a805ed361a0e078bb537e4ea78cd37dcf065
-github.com/vishvananda/netlink b2de5d10e38ecce8607e6b438b6d174f389a004e
-github.com/vishvananda/netns 604eaf189ee867d8c147fafc28def2394e878d25
-golang.org/x/crypto 1a580b3eff7814fc9b40602fd35256c63b50f491
-golang.org/x/net 0ed95abb35c445290478a5348a7b38bb154135fd
-golang.org/x/sys 37707fdb30a5b38865cfb95e5aab41707daec7fd
-golang.org/x/sync fd80eb99c8f653c847d294a001bdf2a3a6f768f5
-github.com/pkg/errors 839d9e913e063e28dfd0e6c7b7512793e0a48be9
-github.com/ishidawataru/sctp 07191f837fedd2f13d1ec7b5f885f0f3ec54b1cb
+github.com/godbus/dbus                  5f6efc7ef2759c81b7ba876593971bfce311eab3 # v4.0.0
+github.com/gogo/protobuf                1adfc126b41513cc696b209667c8656ea7aac67c # v1.0.0
+github.com/gorilla/context              1ea25387ff6f684839d82767c1733ff4d4d15d0a # v1.1
+github.com/gorilla/mux                  0eeaf8392f5b04950925b8a69fe70f110fa7cbfc # v1.1
+github.com/hashicorp/consul             9a9cc9341bb487651a0399e3fc5e1e8a42e62dd9 # v0.5.2
+github.com/hashicorp/go-msgpack         71c2886f5a673a35f909803f38ece5810165097b
+github.com/hashicorp/go-multierror      fcdddc395df1ddf4247c69bd436e84cfa0733f7e
+github.com/hashicorp/memberlist         3d8438da9589e7b608a83ffac1ef8211486bcb7c
+github.com/sean-/seed                   e2103e2c35297fb7e17febb81e49b312087a2372
+github.com/hashicorp/go-sockaddr        6d291a969b86c4b633730bfc6b8b9d64c3aafed9
+github.com/hashicorp/serf               598c54895cc5a7b1a24a398d635e8c0ea0959870
+github.com/mattn/go-shellwords          02e3cf038dcea8290e44424da473dd12be796a8a # v1.0.3
+github.com/miekg/dns                    e57bf427e68187a27e22adceac868350d7a7079b # v1.0.7
+github.com/opencontainers/go-digest     279bed98673dd5bef374d3b6e4b09e2af76183bf # v1.0.0-rc1
+github.com/opencontainers/image-spec    d60099175f88c47cd379c4738d158884749ed235 # v1.0.1
+github.com/opencontainers/runc          96ec2177ae841256168fcf76954f7177af9446eb
+github.com/opencontainers/runtime-spec  5684b8af48c1ac3b1451fa499724e30e3c20a294 # v1.0.1-49-g5684b8a
+github.com/samuel/go-zookeeper          d0e0d8e11f318e000a8cc434616d69e329edc374
+github.com/sirupsen/logrus              f006c2ac4710855cf0f916dd6b77acf6b048dc6e # v1.0.3
+github.com/ugorji/go                    f1f1a805ed361a0e078bb537e4ea78cd37dcf065
+github.com/vishvananda/netlink          b2de5d10e38ecce8607e6b438b6d174f389a004e
+github.com/vishvananda/netns            604eaf189ee867d8c147fafc28def2394e878d25
+golang.org/x/crypto                     0709b304e793a5edb4a2c0145f281ecdc20838a4
+golang.org/x/net                        a680a1efc54dd51c040b3b5ce4939ea3cf2ea0d1
+golang.org/x/sys                        ac767d655b305d4e9612f5f6e33120b9176c4ad4
+golang.org/x/sync                       1d60e4601c6fd243af51cc01ddf169918a5407ca
+github.com/pkg/errors                   645ef00459ed84a119197bfb8d8205042c6df63d # v0.8.0
+github.com/ishidawataru/sctp            07191f837fedd2f13d1ec7b5f885f0f3ec54b1cb
 
-gotest.tools v2.1.0
-github.com/google/go-cmp v0.2.0
+gotest.tools                            b6e20af1ed078cd01a6413b734051a292450b4cb # v2.1.0
+github.com/google/go-cmp                3af367b6b30c263d47e8895973edcca9a49cf029 # v0.2.0


### PR DESCRIPTION
full diff: https://github.com/docker/libnetwork/compare/e7933d41e7b206756115aa9df5e0599fc5169742...55685ba49593e67f5e1c8180539379b16736c25e

changes included:

- docker/libnetwork#2382 Backporting PR 2069 to bump_18.09
  - backport of https://github.com/docker/libnetwork#2069 Rolling back the port configs if failed to programIngress()
- docker/libnetwork#2363 [18.09] align dependencies with engine 18.09
- docker/libnetwork#2400 [18.09 backport] Fix TestValidRemoteDriver GetCapabilities errors
- docker/libnetwork#2391 [18.09 backport] Correctly clean up --config-only networks
  - backport of docker/libnetwork#2373
  - fixes moby/moby#35101
- docker/libnetwork#2392 [18.09 backport] remove gosimple - package is gone and it's not important


