### PR TITLE
[18.09] Bump Go to  1.11.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,9 @@
 # the case. Therefore, you don't have to disable it anymore.
 #
 
-FROM golang:1.11.12 AS base
+ARG GO_VERSION=1.11.12
+
+FROM golang:${GO_VERSION} AS base
 ARG APT_MIRROR
 RUN sed -ri "s/(httpredir|deb).debian.org/${APT_MIRROR:-deb.debian.org}/g" /etc/apt/sources.list \
  && sed -ri "s/(security).debian.org/${APT_MIRROR:-security.debian.org}/g" /etc/apt/sources.list

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,9 +25,9 @@
 #
 
 FROM golang:1.11.12 AS base
-# allow replacing httpredir or deb mirror
-ARG APT_MIRROR=deb.debian.org
-RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
+ARG APT_MIRROR
+RUN sed -ri "s/(httpredir|deb).debian.org/${APT_MIRROR:-deb.debian.org}/g" /etc/apt/sources.list \
+ && sed -ri "s/(security).debian.org/${APT_MIRROR:-security.debian.org}/g" /etc/apt/sources.list
 
 FROM base AS criu
 # Install CRIU for checkpoint/restore support

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@
 # the case. Therefore, you don't have to disable it anymore.
 #
 
-FROM golang:1.11.11 AS base
+FROM golang:1.11.12 AS base
 # allow replacing httpredir or deb mirror
 ARG APT_MIRROR=deb.debian.org
 RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@
 
 ARG GO_VERSION=1.11.12
 
-FROM golang:${GO_VERSION} AS base
+FROM golang:${GO_VERSION}-stretch AS base
 ARG APT_MIRROR
 RUN sed -ri "s/(httpredir|deb).debian.org/${APT_MIRROR:-deb.debian.org}/g" /etc/apt/sources.list \
  && sed -ri "s/(security).debian.org/${APT_MIRROR:-security.debian.org}/g" /etc/apt/sources.list

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -1,14 +1,13 @@
 ## Step 1: Build tests
 FROM golang:1.11.12-alpine3.9 as builder
 
-RUN apk add --update \
+RUN apk --no-cache add \
     bash \
     btrfs-progs-dev \
     build-base \
     curl \
     lvm2-dev \
-    jq \
-    && rm -rf /var/cache/apk/*
+    jq
 
 RUN mkdir -p /go/src/github.com/docker/docker/
 WORKDIR /go/src/github.com/docker/docker/
@@ -43,7 +42,7 @@ RUN mkdir -p /output/tests && find . -name test.main -exec cp --parents '{}' /ou
 FROM alpine:3.9 as runner
 
 # GNU tar is used for generating the emptyfs image
-RUN apk add --update \
+RUN apk --no-cache add \
     bash \
     ca-certificates \
     g++ \
@@ -51,8 +50,7 @@ RUN apk add --update \
     iptables \
     pigz \
     tar \
-    xz \
-    && rm -rf /var/cache/apk/*
+    xz
 
 # Add an unprivileged user to be used for tests which need it
 RUN addgroup docker && adduser -D -G docker unprivilegeduser -s /bin/ash

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -1,5 +1,6 @@
-## Step 1: Build tests
-FROM golang:1.11.12-alpine3.9 as builder
+ARG GO_VERSION=1.11.12
+
+FROM golang:${GO_VERSION}-alpine3.9 AS builder
 
 RUN apk --no-cache add \
     bash \

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -1,5 +1,5 @@
 ## Step 1: Build tests
-FROM golang:1.11.11-alpine3.9 as builder
+FROM golang:1.11.12-alpine3.9 as builder
 
 RUN apk add --update \
     bash \

--- a/Dockerfile.simple
+++ b/Dockerfile.simple
@@ -5,7 +5,7 @@
 
 # This represents the bare minimum required to build and test Docker.
 
-FROM golang:1.11.11-stretch
+FROM golang:1.11.12-stretch
 
 # allow replacing httpredir or deb mirror
 ARG APT_MIRROR=deb.debian.org

--- a/Dockerfile.simple
+++ b/Dockerfile.simple
@@ -5,7 +5,9 @@
 
 # This represents the bare minimum required to build and test Docker.
 
-FROM golang:1.11.12-stretch
+ARG GO_VERSION=1.11.12
+
+FROM golang:${GO_VERSION}-stretch
 
 # allow replacing httpredir or deb mirror
 ARG APT_MIRROR=deb.debian.org

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -161,7 +161,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 # Environment variable notes:
 #  - GO_VERSION must be consistent with 'Dockerfile' used by Linux.
 #  - FROM_DOCKERFILE is used for detection of building within a container.
-ENV GO_VERSION=1.11.11 `
+ENV GO_VERSION=1.11.12 `
     GIT_VERSION=2.11.1 `
     GOPATH=C:\go `
     FROM_DOCKERFILE=1

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -158,10 +158,12 @@ FROM microsoft/windowsservercore
 # Use PowerShell as the default shell
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
+ARG GO_VERSION=1.11.12
+
 # Environment variable notes:
 #  - GO_VERSION must be consistent with 'Dockerfile' used by Linux.
 #  - FROM_DOCKERFILE is used for detection of building within a container.
-ENV GO_VERSION=1.11.12 `
+ENV GO_VERSION=${GO_VERSION} `
     GIT_VERSION=2.11.1 `
     GOPATH=C:\go `
     FROM_DOCKERFILE=1

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -207,7 +207,7 @@ RUN `
   Download-File $location C:\gitsetup.zip; `
   `
   Write-Host INFO: Downloading go...; `
-  Download-File $('https://golang.org/dl/go'+$Env:GO_VERSION+'.windows-amd64.zip') C:\go.zip; `
+  Download-File $('https://golang.org/dl/go'+$Env:GO_VERSION.TrimEnd('.0')"+'.windows-amd64.zip') C:\go.zip; `
   `
   Write-Host INFO: Downloading compiler 1 of 3...; `
   Download-File https://raw.githubusercontent.com/jhowardmsft/docker-tdmgcc/master/gcc.zip C:\gcc.zip; `

--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ dynbinary: build ## build the linux dynbinaries
 build: DOCKER_BUILDKIT ?= 1
 build: bundles
 	$(warning The docker client CLI has moved to github.com/docker/cli. For a dev-test cycle involving the CLI, run:${\n} DOCKER_CLI_PATH=/host/path/to/cli/binary make shell ${\n} then change the cli and compile into a binary at the same location.${\n})
-	DOCKER_BUILDKIT="${DOCKER_BUILDKIT}" docker build ${BUILD_APT_MIRROR} ${DOCKER_BUILD_ARGS} ${DOCKER_BUILD_OPTS} -t "$(DOCKER_IMAGE)" -f "$(DOCKERFILE)" .
+	DOCKER_BUILDKIT="${DOCKER_BUILDKIT}" docker build --build-arg=GO_VERSION ${BUILD_APT_MIRROR} ${DOCKER_BUILD_ARGS} ${DOCKER_BUILD_OPTS} -t "$(DOCKER_IMAGE)" -f "$(DOCKERFILE)" .
 
 bundles:
 	mkdir bundles

--- a/hack/ci/windows.ps1
+++ b/hack/ci/windows.ps1
@@ -426,20 +426,9 @@ Try {
     Write-Host -ForegroundColor Green "INFO: Location for testing is $env:TEMP"
 
     # CI Integrity check - ensure Dockerfile.windows and Dockerfile go versions match
-    $goVersionDockerfileWindows=$(Get-Content ".\Dockerfile.windows" | Select-String "^ENV GO_VERSION" | Select-object -First 1).ToString().Replace("ENV GO_VERSION=","").Replace("\","").Replace("``","").Trim()
-    $goVersionDockerfile=$(Get-Content ".\Dockerfile" | Select-String "^ENV GO_VERSION" | Select-object -First 1)
-    
-    # As of go 1.11, Dockerfile changed to be in the format like "FROM golang:1.11.0 AS base".
-    # If a version number ends with .0 (as in 1.11.0, a convention used in golang docker
-    # image versions), it needs to be removed (i.e. "1.11.0" becomes "1.11").
-    if ($null -eq $goVersionDockerfile) {
-        $goVersionDockerfile=$(Get-Content ".\Dockerfile" | Select-String "^FROM golang:" | Select-object -First 1)
-        if ($null -ne $goVersionDockerfile) {
-            $goVersionDockerfile = $goVersionDockerfile.ToString().Split(" ")[1].Split(":")[1] -replace '\.0$',''
-        }
-    } else {
-        $goVersionDockerfile = $goVersionDockerfile.ToString().Split(" ")[2]
-    }
+    $goVersionDockerfileWindows=(Select-String -Path ".\Dockerfile.windows" -Pattern "^ARG[\s]+GO_VERSION=(.*)$").Matches.groups[1].Value
+    $goVersionDockerfile=(Select-String -Path ".\Dockerfile" -Pattern "^ARG[\s]+GO_VERSION=(.*)$").Matches.groups[1].Value
+
     if ($null -eq $goVersionDockerfile) {
         Throw "ERROR: Failed to extract golang version from Dockerfile"
     }

--- a/hack/ci/windows.ps1
+++ b/hack/ci/windows.ps1
@@ -453,7 +453,7 @@ Try {
         Write-Host  -ForegroundColor Cyan "`n`nINFO: Building the image from Dockerfile.windows at $(Get-Date)..."
         Write-Host
         $ErrorActionPreference = "SilentlyContinue"
-        $Duration=$(Measure-Command { docker build -t docker -f Dockerfile.windows . | Out-Host })
+        $Duration=$(Measure-Command { docker build --build-arg=GO_VERSION -t docker -f Dockerfile.windows . | Out-Host })
         $ErrorActionPreference = "Stop"
         if (-not($LastExitCode -eq 0)) {
            Throw "ERROR: Failed to build image from Dockerfile.windows"

--- a/hack/make.ps1
+++ b/hack/make.ps1
@@ -134,7 +134,7 @@ Function Check-InContainer() {
 # outside of a container where it may be out of date with master.
 Function Verify-GoVersion() {
     Try {
-        $goVersionDockerfile=(Select-String -Path ".\Dockerfile" -Pattern "^FROM golang:").ToString().Split(" ")[1].SubString(7) -replace '\.0$',''
+        $goVersionDockerfile=(Select-String -Path ".\Dockerfile" -Pattern "^ARG[\s]+GO_VERSION=(.*)$").Matches.groups[1].Value.TrimEnd(".0")
         $goVersionInstalled=(go version).ToString().Split(" ")[2].SubString(2)
     }
     Catch [Exception] {


### PR DESCRIPTION
### Bump Go to 1.11.12
go1.11.12 (released 2019/07/08) includes fixes to the compiler and the linker.
See the Go 1.11.12 milestone on our issue tracker for details:
* https://github.com/golang/go/issues?q=milestone%3AGo1.11.12  

Full diff: https://github.com/golang/go/compare/go1.11.11...go1.11.12

### Misc Dockerfile improvements
* moby#37953 Dockerfile.e2e: simplify apk calls
* moby#39537 Dockerfile: Use APT_MIRROR for security.debian.org as well
* moby#39548 Dockerfile: use GO_VERSION build-arg for overriding Go version
* moby#39585 Dockerfile.windows: trim .0 from Go versions
* moby#39586 Windows: fix Golang version checks for GO_VERSION build-arg
* moby#39582 Pin Dockerfile to -stretch variant because it's bust'd
