### PR TITLE
[18.09] Initialize nss libraries in Glibc so that the dynamic libraries are l…

### DIFF
--- a/pkg/chrootarchive/archive.go
+++ b/pkg/chrootarchive/archive.go
@@ -4,12 +4,21 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net"
 	"os"
+	"os/user"
 	"path/filepath"
 
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/idtools"
 )
+
+func init() {
+	// initialize nss libraries in Glibc so that the dynamic libraries are loaded in the host
+	// environment not in the chroot from untrusted files.
+	_, _ = user.Lookup("docker")
+	_, _ = net.LookupHost("localhost")
+}
 
 // NewArchiver returns a new Archiver which uses chrootarchive.Untar
 func NewArchiver(idMapping *idtools.IdentityMapping) *archive.Archiver {


### PR DESCRIPTION
bring in https://github.com/moby/moby/pull/39612

Although current releases from 18.09 branch are not affected because we vendor custom tar package this was recently changed in this branch and requires patching for future releases.

@thaJeztah @tiborvass 