### PR TITLE
[19.03] bump swarmkit to 4fb9e961aba635f0240a140e89ece6d6c2082585 (bump_v19.03)

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -130,7 +130,7 @@ github.com/containerd/ttrpc                         f02858b1457c5ca3aaec3a0803eb
 github.com/gogo/googleapis                          d31c731455cb061f42baff3bda55bad0118b126b # v1.2.0
 
 # cluster
-github.com/docker/swarmkit                          961ec3a56b7b6c311a2137b6a398f9d778fba94b # bump_v19.03 branch
+github.com/docker/swarmkit                          4fb9e961aba635f0240a140e89ece6d6c2082585 # bump_v19.03 branch
 github.com/gogo/protobuf                            ba06b47c162d49f2af050fb4c75bcbc86a159d5c # v1.2.1
 github.com/cloudflare/cfssl                         5d63dbd981b5c408effbb58c442d54761ff94fbd # 1.3.2
 github.com/fernet/fernet-go                         1b2437bc582b3cfbb341ee5a29f8ef5b42912ff2


### PR DESCRIPTION
full diff: https://github.com/docker/swarmkit/compare/961ec3a56b7b6c311a2137b6a398f9d778fba94b...4fb9e961aba635f0240a140e89ece6d6c2082585

included:

- docker/swarmkit#2873 [19.03 backport] Only update non-terminal tasks on node removal
  - backport of docker/swarmkit#2867 Only update non-terminal tasks on node removal


