### PR TITLE
[18.09] bump swarmkit to 142a73731c850daf24d32001aa2358b6ffe36eab (bump_v18.09)

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -130,7 +130,7 @@ github.com/containerd/ttrpc 2a805f71863501300ae1976d29f0454ae003e85a
 github.com/gogo/googleapis 08a7655d27152912db7aaf4f983275eaf8d128ef
 
 # cluster
-github.com/docker/swarmkit 19e791fd6dc76e8e894cbc99b77f946b7d00ebb9 # bump_v18.09 branch
+github.com/docker/swarmkit 142a73731c850daf24d32001aa2358b6ffe36eab # bump_v18.09 branch
 github.com/gogo/protobuf v1.0.0
 github.com/cloudflare/cfssl 1.3.2
 github.com/fernet/fernet-go 1b2437bc582b3cfbb341ee5a29f8ef5b42912ff2


### PR DESCRIPTION
full diff: https://github.com/docker/swarmkit/compare/19e791fd6dc76e8e894cbc99b77f946b7d00ebb9...142a73731c850daf24d32001aa2358b6ffe36eab

included:

- docker/swarmkit#2872 [19.03 backport] Only update non-terminal tasks on node removal
  - backport of docker/swarmkit#2867 Only update non-terminal tasks on node removal

