### PR TITLE
[18.09 backport] projectquota: protect concurrent map access (ENGCORE-920)

### DIFF
--- a/daemon/graphdriver/copy/copy.go
+++ b/daemon/graphdriver/copy/copy.go
@@ -2,14 +2,6 @@
 
 package copy // import "github.com/docker/docker/daemon/graphdriver/copy"
 
-/*
-#include <linux/fs.h>
-
-#ifndef FICLONE
-#define FICLONE		_IOW(0x94, 9, int)
-#endif
-*/
-import "C"
 import (
 	"container/list"
 	"fmt"
@@ -50,7 +42,7 @@ func copyRegular(srcPath, dstPath string, fileinfo os.FileInfo, copyWithFileRang
 	defer dstFile.Close()
 
 	if *copyWithFileClone {
-		_, _, err = unix.Syscall(unix.SYS_IOCTL, dstFile.Fd(), C.FICLONE, srcFile.Fd())
+		err = fiClone(srcFile, dstFile)
 		if err == nil {
 			return nil
 		}

--- a/daemon/graphdriver/copy/copy_cgo.go
+++ b/daemon/graphdriver/copy/copy_cgo.go
@@ -1,0 +1,22 @@
+// +build linux,cgo
+
+package copy // import "github.com/docker/docker/daemon/graphdriver/copy"
+
+/*
+#include <linux/fs.h>
+
+#ifndef FICLONE
+#define FICLONE		_IOW(0x94, 9, int)
+#endif
+*/
+import "C"
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func fiClone(srcFile, dstFile *os.File) error {
+	_, _, err := unix.Syscall(unix.SYS_IOCTL, dstFile.Fd(), C.FICLONE, srcFile.Fd())
+	return err
+}

--- a/daemon/graphdriver/copy/copy_nocgo.go
+++ b/daemon/graphdriver/copy/copy_nocgo.go
@@ -1,0 +1,13 @@
+// +build linux,!cgo
+
+package copy // import "github.com/docker/docker/daemon/graphdriver/copy"
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func fiClone(srcFile, dstFile *os.File) error {
+	return unix.ENOSYS
+}

--- a/daemon/graphdriver/quota/projectquota.go
+++ b/daemon/graphdriver/quota/projectquota.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build linux,!exclude_disk_quota
 
 //
 // projectquota.go - implements XFS project quota controls
@@ -62,19 +62,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
-
-// Quota limit params - currently we only control blocks hard limit
-type Quota struct {
-	Size uint64
-}
-
-// Control - Context to be used by storage driver (e.g. overlay)
-// who wants to apply project quotas to container dirs
-type Control struct {
-	backingFsBlockDev string
-	nextProjectID     uint32
-	quotas            map[string]uint32
-}
 
 // NewControl - initialize project quota support.
 // Test to make sure that quota can be set on a test dir and find

--- a/daemon/graphdriver/quota/projectquota.go
+++ b/daemon/graphdriver/quota/projectquota.go
@@ -153,9 +153,11 @@ func NewControl(basePath string) (*Control, error) {
 // SetQuota - assign a unique project id to directory and set the quota limits
 // for that project id
 func (q *Control) SetQuota(targetPath string, quota Quota) error {
-
+	q.RLock()
 	projectID, ok := q.quotas[targetPath]
+	q.RUnlock()
 	if !ok {
+		q.Lock()
 		projectID = q.nextProjectID
 
 		//
@@ -163,11 +165,12 @@ func (q *Control) SetQuota(targetPath string, quota Quota) error {
 		//
 		err := setProjectID(targetPath, projectID)
 		if err != nil {
+			q.Unlock()
 			return err
 		}
-
 		q.quotas[targetPath] = projectID
 		q.nextProjectID++
+		q.Unlock()
 	}
 
 	//
@@ -204,8 +207,9 @@ func setProjectQuota(backingFsBlockDev string, projectID uint32, quota Quota) er
 
 // GetQuota - get the quota limits of a directory that was configured with SetQuota
 func (q *Control) GetQuota(targetPath string, quota *Quota) error {
-
+	q.RLock()
 	projectID, ok := q.quotas[targetPath]
+	q.RUnlock()
 	if !ok {
 		return fmt.Errorf("quota not found for path : %s", targetPath)
 	}
@@ -276,6 +280,8 @@ func setProjectID(targetPath string, projectID uint32) error {
 // findNextProjectID - find the next project id to be used for containers
 // by scanning driver home directory to find used project ids
 func (q *Control) findNextProjectID(home string) error {
+	q.Lock()
+	defer q.Unlock()
 	files, err := ioutil.ReadDir(home)
 	if err != nil {
 		return fmt.Errorf("read directory failed : %s", home)

--- a/daemon/graphdriver/quota/projectquota_unsupported.go
+++ b/daemon/graphdriver/quota/projectquota_unsupported.go
@@ -1,0 +1,18 @@
+// +build linux,exclude_disk_quota
+
+package quota // import "github.com/docker/docker/daemon/graphdriver/quota"
+
+func NewControl(basePath string) (*Control, error) {
+	return nil, ErrQuotaNotSupported
+}
+
+// SetQuota - assign a unique project id to directory and set the quota limits
+// for that project id
+func (q *Control) SetQuota(targetPath string, quota Quota) error {
+	return ErrQuotaNotSupported
+}
+
+// GetQuota - get the quota limits of a directory that was configured with SetQuota
+func (q *Control) GetQuota(targetPath string, quota *Quota) error {
+	return ErrQuotaNotSupported
+}

--- a/daemon/graphdriver/quota/types.go
+++ b/daemon/graphdriver/quota/types.go
@@ -1,0 +1,16 @@
+// +build linux
+
+package quota // import "github.com/docker/docker/daemon/graphdriver/quota"
+
+// Quota limit params - currently we only control blocks hard limit
+type Quota struct {
+	Size uint64
+}
+
+// Control - Context to be used by storage driver (e.g. overlay)
+// who wants to apply project quotas to container dirs
+type Control struct {
+	backingFsBlockDev string
+	nextProjectID     uint32
+	quotas            map[string]uint32
+}

--- a/daemon/graphdriver/quota/types.go
+++ b/daemon/graphdriver/quota/types.go
@@ -2,6 +2,8 @@
 
 package quota // import "github.com/docker/docker/daemon/graphdriver/quota"
 
+import "sync"
+
 // Quota limit params - currently we only control blocks hard limit
 type Quota struct {
 	Size uint64
@@ -11,6 +13,7 @@ type Quota struct {
 // who wants to apply project quotas to container dirs
 type Control struct {
 	backingFsBlockDev string
+	sync.RWMutex      // protect nextProjectID and quotas map
 	nextProjectID     uint32
 	quotas            map[string]uint32
 }


### PR DESCRIPTION
This is a backport of
* https://github.com/moby/moby/pull/39327 allow dockerd builds without cgo
* https://github.com/moby/moby/pull/39644 projectquota: protect concurrent map access (ENGCORE-920)
 
to address

* https://github.com/moby/moby/issues/39643 Docker daemon crashes (again) with "fatal error: concurrent map read and map write"

Clean cherry-pick, no issues (https://github.com/moby/moby/pull/39327 is required solely for a clean cherry-pick)