### PR TITLE
[19.03 backport] Fix regression in handling of NotFound err during startup ENGCORE-929

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -335,7 +335,7 @@ func (daemon *Daemon) restore() error {
 			}
 			if !alive && process != nil {
 				ec, exitedAt, err = process.Delete(context.Background())
-				if err != nil {
+				if err != nil && !errdefs.IsNotFound(err) {
 					logrus.WithError(err).Errorf("Failed to delete container %s from containerd", c.ID)
 					return
 				}


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/39703 for 19.03

Signed-off-by: Deep Debroy <ddebroy@docker.com>
(cherry picked from commit 4d5b6260bc595d5d9787c67ae887e83432911380)
Signed-off-by: Sebastiaan van Stijn <github@gone.nl>

**- What I did**
Address a regression during daemon startup introduced in https://github.com/moby/moby/pull/38931.

fixes https://github.com/moby/moby/issues/39623
fixes https://github.com/docker/for-win/issues/4463
fixes https://github.com/microsoft/navcontainerhelper/issues/548

**- How I did it**
Added (back) proper handling of NotFound err

**- How to verify it**
Start a container in Windows like: 
```
docker run -d --restart always --name testcontainer --network nat -p 8080:80 mcr.microsoft.com/windows/servercore:ltsc2019 ping -t 127.0.0.1
```
and Restart-Computer.
After reboot, make sure container comes back up properly and is not a zombie.

**- Description for the changelog**
Fix regression in reboot of Windows daemon

**- A picture of a cute animal (not mandatory but encouraged)**

