### PR TITLE
[19.03 backport] do not stop health check before sending signal

### DIFF
--- a/daemon/kill.go
+++ b/daemon/kill.go
@@ -64,8 +64,6 @@ func (daemon *Daemon) killWithSignal(container *containerpkg.Container, sig int)
 	container.Lock()
 	defer container.Unlock()
 
-	daemon.stopHealthchecks(container)
-
 	if !container.Running {
 		return errNotRunning(container.ID)
 	}

--- a/integration-cli/docker_cli_health_test.go
+++ b/integration-cli/docker_cli_health_test.go
@@ -165,3 +165,29 @@ ENTRYPOINT /bin/sh -c "sleep 600"`))
 	waitForHealthStatus(c, name, "starting", "healthy")
 
 }
+
+// GitHub #37263
+func (s *DockerSuite) TestHealthKillContainer(c *check.C) {
+	testRequires(c, DaemonIsLinux) // busybox doesn't work on Windows
+
+	imageName := "testhealth"
+	buildImageSuccessfully(c, imageName, build.WithDockerfile(`FROM busybox
+HEALTHCHECK --interval=1s --timeout=5s --retries=5 CMD /bin/sh -c "sleep 1"
+ENTRYPOINT /bin/sh -c "sleep 600"`))
+
+	name := "test_health_kill"
+	dockerCmd(c, "run", "-d", "--name", name, imageName)
+	defer func() {
+		dockerCmd(c, "rm", "-f", name)
+		dockerCmd(c, "rmi", imageName)
+	}()
+
+	// Start
+	dockerCmd(c, "start", name)
+	waitForHealthStatus(c, name, "starting", "healthy")
+
+	dockerCmd(c, "kill", "-s", "SIGINT", name)
+	out, _ := dockerCmd(c, "inspect", "--format={{.State.Health.Status}}", name)
+	c.Check(out, checker.Equals, "healthy\n")
+
+}

--- a/integration/container/health_test.go
+++ b/integration/container/health_test.go
@@ -9,6 +9,7 @@ import (
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/integration/internal/container"
+	"gotest.tools/assert"
 	"gotest.tools/poll"
 	"gotest.tools/skip"
 )
@@ -30,6 +31,34 @@ func TestHealthCheckWorkdir(t *testing.T) {
 	})
 
 	poll.WaitOn(t, pollForHealthStatus(ctx, client, cID, types.Healthy), poll.WithDelay(100*time.Millisecond))
+}
+
+// GitHub #37263
+// Do not stop healthchecks just because we sent a signal to the container
+func TestHealthKillContainer(t *testing.T) {
+	defer setupTest(t)()
+
+	ctx := context.Background()
+	client := testEnv.APIClient()
+
+	id := container.Run(ctx, t, client, func(c *container.TestContainerConfig) {
+		c.Config.Healthcheck = &containertypes.HealthConfig{
+			Test:     []string{"CMD-SHELL", "sleep 1"},
+			Interval: time.Second,
+			Retries:  5,
+		}
+	})
+
+	ctxPoll, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	poll.WaitOn(t, pollForHealthStatus(ctxPoll, client, id, "healthy"), poll.WithDelay(100*time.Millisecond))
+
+	err := client.ContainerKill(ctx, id, "SIGUSR1")
+	assert.NilError(t, err)
+
+	ctxPoll, cancel = context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	poll.WaitOn(t, pollForHealthStatus(ctxPoll, client, id, "healthy"), poll.WithDelay(100*time.Millisecond))
 }
 
 func pollForHealthStatus(ctx context.Context, client client.APIClient, containerID string, healthStatus string) func(log poll.LogT) poll.Result {

--- a/integration/container/health_test.go
+++ b/integration/container/health_test.go
@@ -42,7 +42,7 @@ func TestHealthKillContainer(t *testing.T) {
 	ctx := context.Background()
 	client := testEnv.APIClient()
 
-	id := container.Run(ctx, t, client, func(c *container.TestContainerConfig) {
+	id := container.Run(t, ctx, client, func(c *container.TestContainerConfig) {
 		c.Config.Healthcheck = &containertypes.HealthConfig{
 			Test:     []string{"CMD-SHELL", "sleep 1"},
 			Interval: time.Second,

--- a/integration/container/health_test.go
+++ b/integration/container/health_test.go
@@ -36,6 +36,7 @@ func TestHealthCheckWorkdir(t *testing.T) {
 // GitHub #37263
 // Do not stop healthchecks just because we sent a signal to the container
 func TestHealthKillContainer(t *testing.T) {
+	skip.If(t, testEnv.OSType == "windows", "Windows only supports SIGKILL and SIGTERM? See https://github.com/moby/moby/issues/39574")
 	defer setupTest(t)()
 
 	ctx := context.Background()


### PR DESCRIPTION
https://github.com/moby/moby/pull/39454

Just to summarize, the concern in this backport  is the risk of leaking health monitor routines. Those routines need to be explicitly stopped.
The only other place where we explicitly  stop those threads , is when we get an event from containerd, so as long as those events are delivered, we should be good.

Note, this is the change that introduced the original problem and you can see how the health monitor was explicitly stopped, (in addition to the containerd event)
https://github.com/moby/moby/pull/35501

Had a chat with @crosbymichael and @thaJeztah we decided to go ahead with the port , unless someone else has any concerns
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

