### PR TITLE
[18.09 backport] Harden TestClientWithRequestTimeout

### DIFF
--- a/pkg/plugins/client_test.go
+++ b/pkg/plugins/client_test.go
@@ -2,7 +2,6 @@ package plugins // import "github.com/docker/docker/pkg/plugins"
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -237,6 +236,10 @@ func TestClientSendFile(t *testing.T) {
 }
 
 func TestClientWithRequestTimeout(t *testing.T) {
+	type timeoutError interface {
+		Timeout() bool
+	}
+
 	timeout := 1 * time.Millisecond
 	testHandler := func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(timeout + 1*time.Millisecond)
@@ -251,12 +254,8 @@ func TestClientWithRequestTimeout(t *testing.T) {
 	assert.Assert(t, is.ErrorContains(err, ""), "expected error")
 
 	err = errors.Cause(err)
-
-	switch e := err.(type) {
-	case *url.Error:
-		err = e.Err
-	}
-	assert.DeepEqual(t, context.DeadlineExceeded, err)
+	assert.ErrorType(t, err, (*timeoutError)(nil))
+	assert.Equal(t, err.(timeoutError).Timeout(), true)
 }
 
 type testRequestWrapper struct {


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/39168


DeadlineExceeded now implements a TimeOut() function,
since https://github.com/golang/go/commit/dc4427f3727804ded270bc6a7a8066ccb3c151d0

Check for this interface, to prevent possibly incorrect failures;

```
00:16:41 --- FAIL: TestClientWithRequestTimeout (0.00s)
00:16:41     client_test.go:259: assertion failed:
00:16:41         --- context.DeadlineExceeded
00:16:41         +++ err
00:16:41         :
00:16:41         	-: context.deadlineExceededError{}
00:16:41         	+: &net.OpError{Op: "dial", Net: "tcp", Addr: s"127.0.0.1:49294", Err: &poll.TimeoutError{}}
00:16:41
```
