### PR TITLE
[18.09 backport] Fix overlay2 busy error on mount

### DIFF
--- a/daemon/graphdriver/overlay2/check.go
+++ b/daemon/graphdriver/overlay2/check.go
@@ -43,10 +43,10 @@ func doesSupportNativeDiff(d string) error {
 	if err := os.Mkdir(filepath.Join(td, "l3"), 0755); err != nil {
 		return err
 	}
-	if err := os.Mkdir(filepath.Join(td, "work"), 0755); err != nil {
+	if err := os.Mkdir(filepath.Join(td, workDirName), 0755); err != nil {
 		return err
 	}
-	if err := os.Mkdir(filepath.Join(td, "merged"), 0755); err != nil {
+	if err := os.Mkdir(filepath.Join(td, mergedDirName), 0755); err != nil {
 		return err
 	}
 
@@ -55,18 +55,18 @@ func doesSupportNativeDiff(d string) error {
 		return errors.Wrap(err, "failed to set opaque flag on middle layer")
 	}
 
-	opts := fmt.Sprintf("lowerdir=%s:%s,upperdir=%s,workdir=%s", path.Join(td, "l2"), path.Join(td, "l1"), path.Join(td, "l3"), path.Join(td, "work"))
-	if err := unix.Mount("overlay", filepath.Join(td, "merged"), "overlay", 0, opts); err != nil {
+	opts := fmt.Sprintf("lowerdir=%s:%s,upperdir=%s,workdir=%s", path.Join(td, "l2"), path.Join(td, "l1"), path.Join(td, "l3"), path.Join(td, workDirName))
+	if err := unix.Mount("overlay", filepath.Join(td, mergedDirName), "overlay", 0, opts); err != nil {
 		return errors.Wrap(err, "failed to mount overlay")
 	}
 	defer func() {
-		if err := unix.Unmount(filepath.Join(td, "merged"), 0); err != nil {
-			logger.Warnf("Failed to unmount check directory %v: %v", filepath.Join(td, "merged"), err)
+		if err := unix.Unmount(filepath.Join(td, mergedDirName), 0); err != nil {
+			logger.Warnf("Failed to unmount check directory %v: %v", filepath.Join(td, mergedDirName), err)
 		}
 	}()
 
 	// Touch file in d to force copy up of opaque directory "d" from "l2" to "l3"
-	if err := ioutil.WriteFile(filepath.Join(td, "merged", "d", "f"), []byte{}, 0644); err != nil {
+	if err := ioutil.WriteFile(filepath.Join(td, mergedDirName, "d", "f"), []byte{}, 0644); err != nil {
 		return errors.Wrap(err, "failed to write to merged directory")
 	}
 
@@ -80,7 +80,7 @@ func doesSupportNativeDiff(d string) error {
 	}
 
 	// rename "d1" to "d2"
-	if err := os.Rename(filepath.Join(td, "merged", "d1"), filepath.Join(td, "merged", "d2")); err != nil {
+	if err := os.Rename(filepath.Join(td, mergedDirName, "d1"), filepath.Join(td, mergedDirName, "d2")); err != nil {
 		// if rename failed with syscall.EXDEV, the kernel doesn't have CONFIG_OVERLAY_FS_REDIRECT_DIR enabled
 		if err.(*os.LinkError).Err == syscall.EXDEV {
 			return nil
@@ -116,18 +116,18 @@ func supportsMultipleLowerDir(d string) error {
 		}
 	}()
 
-	for _, dir := range []string{"lower1", "lower2", "upper", "work", "merged"} {
+	for _, dir := range []string{"lower1", "lower2", "upper", workDirName, mergedDirName} {
 		if err := os.Mkdir(filepath.Join(td, dir), 0755); err != nil {
 			return err
 		}
 	}
 
-	opts := fmt.Sprintf("lowerdir=%s:%s,upperdir=%s,workdir=%s", path.Join(td, "lower2"), path.Join(td, "lower1"), path.Join(td, "upper"), path.Join(td, "work"))
-	if err := unix.Mount("overlay", filepath.Join(td, "merged"), "overlay", 0, opts); err != nil {
+	opts := fmt.Sprintf("lowerdir=%s:%s,upperdir=%s,workdir=%s", path.Join(td, "lower2"), path.Join(td, "lower1"), path.Join(td, "upper"), path.Join(td, workDirName))
+	if err := unix.Mount("overlay", filepath.Join(td, mergedDirName), "overlay", 0, opts); err != nil {
 		return errors.Wrap(err, "failed to mount overlay")
 	}
-	if err := unix.Unmount(filepath.Join(td, "merged"), 0); err != nil {
-		logger.Warnf("Failed to unmount check directory %v: %v", filepath.Join(td, "merged"), err)
+	if err := unix.Unmount(filepath.Join(td, mergedDirName), 0); err != nil {
+		logger.Warnf("Failed to unmount check directory %v: %v", filepath.Join(td, mergedDirName), err)
 	}
 	return nil
 }

--- a/daemon/graphdriver/overlay2/overlay.go
+++ b/daemon/graphdriver/overlay2/overlay.go
@@ -446,6 +446,10 @@ func (d *Driver) create(id, parent string, opts *graphdriver.CreateOpts) (retErr
 		return err
 	}
 
+	if err := ioutil.WriteFile(path.Join(d.dir(parent), "committed"), []byte{}, 0600); err != nil {
+		return err
+	}
+
 	lower, err := d.getLower(parent)
 	if err != nil {
 		return err
@@ -592,7 +596,20 @@ func (d *Driver) Get(id, mountLabel string) (_ containerfs.ContainerFS, retErr e
 	for i, s := range splitLowers {
 		absLowers[i] = path.Join(d.home, s)
 	}
-	opts := indexOff + "lowerdir=" + strings.Join(absLowers, ":") + ",upperdir=" + diffDir + ",workdir=" + workDir
+	var readonly bool
+	if _, err := os.Stat(path.Join(dir, "committed")); err == nil {
+		readonly = true
+	} else if !os.IsNotExist(err) {
+		return nil, err
+	}
+
+	var opts string
+	if readonly {
+		opts = indexOff + "lowerdir=" + diffDir + ":" + strings.Join(absLowers, ":")
+	} else {
+		opts = indexOff + "lowerdir=" + strings.Join(absLowers, ":") + ",upperdir=" + diffDir + ",workdir=" + workDir
+	}
+
 	mountData := label.FormatMountLabel(opts, mountLabel)
 	mount := unix.Mount
 	mountTarget := mergedDir
@@ -621,7 +638,11 @@ func (d *Driver) Get(id, mountLabel string) (_ containerfs.ContainerFS, retErr e
 	// fit within a page and relative links make the mount data much
 	// smaller at the expense of requiring a fork exec to chroot.
 	if len(mountData) > pageSize {
-		opts = indexOff + "lowerdir=" + string(lowers) + ",upperdir=" + path.Join(id, diffDirName) + ",workdir=" + path.Join(id, workDirName)
+		if readonly {
+			opts = indexOff + "lowerdir=" + path.Join(id, diffDirName) + ":" + string(lowers)
+		} else {
+			opts = indexOff + "lowerdir=" + string(lowers) + ",upperdir=" + path.Join(id, diffDirName) + ",workdir=" + path.Join(id, workDirName)
+		}
 		mountData = label.FormatMountLabel(opts, mountLabel)
 		if len(mountData) > pageSize {
 			return nil, fmt.Errorf("cannot mount layer, mount label too large %d", len(mountData))
@@ -637,10 +658,12 @@ func (d *Driver) Get(id, mountLabel string) (_ containerfs.ContainerFS, retErr e
 		return nil, fmt.Errorf("error creating overlay mount to %s: %v", mergedDir, err)
 	}
 
-	// chown "workdir/work" to the remapped root UID/GID. Overlay fs inside a
-	// user namespace requires this to move a directory from lower to upper.
-	if err := os.Chown(path.Join(workDir, workDirName), rootUID, rootGID); err != nil {
-		return nil, err
+	if !readonly {
+		// chown "workdir/work" to the remapped root UID/GID. Overlay fs inside a
+		// user namespace requires this to move a directory from lower to upper.
+		if err := os.Chown(path.Join(workDir, workDirName), rootUID, rootGID); err != nil {
+			return nil, err
+		}
 	}
 
 	return containerfs.NewLocalContainerFS(mergedDir), nil

--- a/daemon/graphdriver/overlay2/overlay.go
+++ b/daemon/graphdriver/overlay2/overlay.go
@@ -71,10 +71,13 @@ var (
 // that mounts do not fail due to length.
 
 const (
-	driverName = "overlay2"
-	linkDir    = "l"
-	lowerFile  = "lower"
-	maxDepth   = 128
+	driverName    = "overlay2"
+	linkDir       = "l"
+	diffDirName   = "diff"
+	workDirName   = "work"
+	mergedDirName = "merged"
+	lowerFile     = "lower"
+	maxDepth      = 128
 
 	// idLength represents the number of random characters
 	// which can be used to create the unique link identifier
@@ -326,9 +329,9 @@ func (d *Driver) GetMetadata(id string) (map[string]string, error) {
 	}
 
 	metadata := map[string]string{
-		"WorkDir":   path.Join(dir, "work"),
-		"MergedDir": path.Join(dir, "merged"),
-		"UpperDir":  path.Join(dir, "diff"),
+		"WorkDir":   path.Join(dir, workDirName),
+		"MergedDir": path.Join(dir, mergedDirName),
+		"UpperDir":  path.Join(dir, diffDirName),
 	}
 
 	lowerDirs, err := d.getLowerDirs(id)
@@ -420,12 +423,12 @@ func (d *Driver) create(id, parent string, opts *graphdriver.CreateOpts) (retErr
 		}
 	}
 
-	if err := idtools.MkdirAndChown(path.Join(dir, "diff"), 0755, root); err != nil {
+	if err := idtools.MkdirAndChown(path.Join(dir, diffDirName), 0755, root); err != nil {
 		return err
 	}
 
 	lid := generateID(idLength)
-	if err := os.Symlink(path.Join("..", id, "diff"), path.Join(d.home, linkDir, lid)); err != nil {
+	if err := os.Symlink(path.Join("..", id, diffDirName), path.Join(d.home, linkDir, lid)); err != nil {
 		return err
 	}
 
@@ -439,7 +442,7 @@ func (d *Driver) create(id, parent string, opts *graphdriver.CreateOpts) (retErr
 		return nil
 	}
 
-	if err := idtools.MkdirAndChown(path.Join(dir, "work"), 0700, root); err != nil {
+	if err := idtools.MkdirAndChown(path.Join(dir, workDirName), 0700, root); err != nil {
 		return err
 	}
 
@@ -555,7 +558,7 @@ func (d *Driver) Get(id, mountLabel string) (_ containerfs.ContainerFS, retErr e
 		return nil, err
 	}
 
-	diffDir := path.Join(dir, "diff")
+	diffDir := path.Join(dir, diffDirName)
 	lowers, err := ioutil.ReadFile(path.Join(dir, lowerFile))
 	if err != nil {
 		// If no lower, just return diff directory
@@ -565,7 +568,7 @@ func (d *Driver) Get(id, mountLabel string) (_ containerfs.ContainerFS, retErr e
 		return nil, err
 	}
 
-	mergedDir := path.Join(dir, "merged")
+	mergedDir := path.Join(dir, mergedDirName)
 	if count := d.ctr.Increment(mergedDir); count > 1 {
 		return containerfs.NewLocalContainerFS(mergedDir), nil
 	}
@@ -583,13 +586,13 @@ func (d *Driver) Get(id, mountLabel string) (_ containerfs.ContainerFS, retErr e
 		}
 	}()
 
-	workDir := path.Join(dir, "work")
+	workDir := path.Join(dir, workDirName)
 	splitLowers := strings.Split(string(lowers), ":")
 	absLowers := make([]string, len(splitLowers))
 	for i, s := range splitLowers {
 		absLowers[i] = path.Join(d.home, s)
 	}
-	opts := indexOff + "lowerdir=" + strings.Join(absLowers, ":") + ",upperdir=" + path.Join(dir, "diff") + ",workdir=" + path.Join(dir, "work")
+	opts := indexOff + "lowerdir=" + strings.Join(absLowers, ":") + ",upperdir=" + diffDir + ",workdir=" + workDir
 	mountData := label.FormatMountLabel(opts, mountLabel)
 	mount := unix.Mount
 	mountTarget := mergedDir
@@ -618,7 +621,7 @@ func (d *Driver) Get(id, mountLabel string) (_ containerfs.ContainerFS, retErr e
 	// fit within a page and relative links make the mount data much
 	// smaller at the expense of requiring a fork exec to chroot.
 	if len(mountData) > pageSize {
-		opts = indexOff + "lowerdir=" + string(lowers) + ",upperdir=" + path.Join(id, "diff") + ",workdir=" + path.Join(id, "work")
+		opts = indexOff + "lowerdir=" + string(lowers) + ",upperdir=" + path.Join(id, diffDirName) + ",workdir=" + path.Join(id, workDirName)
 		mountData = label.FormatMountLabel(opts, mountLabel)
 		if len(mountData) > pageSize {
 			return nil, fmt.Errorf("cannot mount layer, mount label too large %d", len(mountData))
@@ -627,7 +630,7 @@ func (d *Driver) Get(id, mountLabel string) (_ containerfs.ContainerFS, retErr e
 		mount = func(source string, target string, mType string, flags uintptr, label string) error {
 			return mountFrom(d.home, source, target, mType, flags, label)
 		}
-		mountTarget = path.Join(id, "merged")
+		mountTarget = path.Join(id, mergedDirName)
 	}
 
 	if err := mount("overlay", mountTarget, "overlay", 0, mountData); err != nil {
@@ -636,7 +639,7 @@ func (d *Driver) Get(id, mountLabel string) (_ containerfs.ContainerFS, retErr e
 
 	// chown "workdir/work" to the remapped root UID/GID. Overlay fs inside a
 	// user namespace requires this to move a directory from lower to upper.
-	if err := os.Chown(path.Join(workDir, "work"), rootUID, rootGID); err != nil {
+	if err := os.Chown(path.Join(workDir, workDirName), rootUID, rootGID); err != nil {
 		return nil, err
 	}
 
@@ -659,7 +662,7 @@ func (d *Driver) Put(id string) error {
 		return err
 	}
 
-	mountpoint := path.Join(dir, "merged")
+	mountpoint := path.Join(dir, mergedDirName)
 	if count := d.ctr.Decrement(mountpoint); count > 0 {
 		return nil
 	}
@@ -732,7 +735,7 @@ func (d *Driver) ApplyDiff(id string, parent string, diff io.Reader) (size int64
 func (d *Driver) getDiffPath(id string) string {
 	dir := d.dir(id)
 
-	return path.Join(dir, "diff")
+	return path.Join(dir, diffDirName)
 }
 
 // DiffSize calculates the changes between the specified id


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/38968 and https://github.com/moby/moby/pull/39780 for 19.03


When mounting overlays which have children, enforce that
the mount is always performed as read only. Newer versions
of the kernel return a device busy error when a lower directory
is in use as an upper directory in another overlay mount.

Adds committed file to indicate when an overlay is being used
as a parent, ensuring it will no longer be mounted with an
upper directory.

Related to [kernel@146d62e5a586](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=146d62e5a5867fbf84490d82455718bfb10fe824)