### PR TITLE
[18.09 backport] Add sigprocmask to default seccomp profile (ENGCORE-980)

### DIFF
--- a/profiles/seccomp/default.json
+++ b/profiles/seccomp/default.json
@@ -313,6 +313,7 @@
 				"sigaltstack",
 				"signalfd",
 				"signalfd4",
+				"sigprocmask",
 				"sigreturn",
 				"socket",
 				"socketcall",

--- a/profiles/seccomp/seccomp_default.go
+++ b/profiles/seccomp/seccomp_default.go
@@ -306,6 +306,7 @@ func DefaultProfile() *types.Seccomp {
 				"sigaltstack",
 				"signalfd",
 				"signalfd4",
+				"sigprocmask",
 				"sigreturn",
 				"socket",
 				"socketcall",


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/39824
addresses [ENGCORE-976]
fixes [ENGCORE-980]

[ENGCORE-976]: https://docker.atlassian.net/browse/ENGCORE-976
[ENGCORE-980]: https://docker.atlassian.net/browse/ENGCORE-980