### PR TITLE
[18.09 backport] Improve readability of Windows connect error

### DIFF
--- a/client/request.go
+++ b/client/request.go
@@ -176,7 +176,13 @@ func (cli *Client) doRequest(ctx context.Context, req *http.Request) (serverResp
 		// this is localised - for example in French the error would be
 		// `open //./pipe/docker_engine: Le fichier spécifié est introuvable.`
 		if strings.Contains(err.Error(), `open //./pipe/docker_engine`) {
-			err = errors.New(err.Error() + " In the default daemon configuration on Windows, the docker client must be run elevated to connect. This error may also indicate that the docker daemon is not running.")
+			// Checks if client is running with elevated privileges
+			if f, elevatedErr := os.Open("\\\\.\\PHYSICALDRIVE0"); elevatedErr == nil {
+				err = errors.Wrap(err, "In the default daemon configuration on Windows, the docker client must be run with elevated privileges to connect.")
+			} else {
+				f.Close()
+				err = errors.Wrap(err, "This error may indicate that the docker daemon is not running.")
+			}
 		}
 
 		return serverResp, errors.Wrap(err, "error during connect")


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/39588
addresses [DESKTOP-1286]

Improve the readability of the connection error displayed to the user on
Windows when running docker commands fails by checking if the client is
privileged. If so then display the actual error wrapped in a generic
error "This error may indicate that the docker daemon is not running."

If not that display the actual error wrapped in a more specific error:
"In the default daemon configuration on Windows, the docker client must
be run with elevated privileges to connect."


[DESKTOP-1286]: https://docker.atlassian.net/browse/DESKTOP-1286