### PR TITLE
[19.03 backport] integration-cli: fix swarm tests flakiness

### DIFF
--- a/integration-cli/docker_cli_swarm_test.go
+++ b/integration-cli/docker_cli_swarm_test.go
@@ -1303,9 +1303,21 @@ func (s *DockerSwarmSuite) TestSwarmRotateUnlockKey(c *check.C) {
 
 		c.Assert(getNodeStatus(c, d), checker.Equals, swarm.LocalNodeStateActive)
 
-		outs, err = d.Cmd("node", "ls")
-		assert.NilError(c, err)
-		c.Assert(outs, checker.Not(checker.Contains), "Swarm is encrypted and needs to be unlocked")
+		retry := 0
+		for {
+			// an issue sometimes prevents leader to be available right away
+			outs, err = d.Cmd("node", "ls")
+			if err != nil && retry < 5 {
+				if strings.Contains(err.Error(), "swarm does not have a leader") {
+					retry++
+					time.Sleep(3 * time.Second)
+					continue
+				}
+			}
+			assert.NilError(c, err)
+			c.Assert(outs, checker.Not(checker.Contains), "Swarm is encrypted and needs to be unlocked")
+			break
+		}
 
 		unlockKey = newUnlockKey
 	}
@@ -1383,9 +1395,21 @@ func (s *DockerSwarmSuite) TestSwarmClusterRotateUnlockKey(c *check.C) {
 
 			c.Assert(getNodeStatus(c, d), checker.Equals, swarm.LocalNodeStateActive)
 
-			outs, err = d.Cmd("node", "ls")
-			c.Assert(err, checker.IsNil, check.Commentf("%s", outs))
-			c.Assert(outs, checker.Not(checker.Contains), "Swarm is encrypted and needs to be unlocked")
+			retry := 0
+			for {
+				// an issue sometimes prevents leader to be available right away
+				outs, err = d.Cmd("node", "ls")
+				if err != nil && retry < 5 {
+					if strings.Contains(err.Error(), "swarm does not have a leader") {
+						retry++
+						time.Sleep(3 * time.Second)
+						continue
+					}
+				}
+				c.Assert(err, checker.IsNil, check.Commentf("%s", outs))
+				c.Assert(outs, checker.Not(checker.Contains), "Swarm is encrypted and needs to be unlocked")
+				break
+			}
 		}
 
 		unlockKey = newUnlockKey

--- a/integration-cli/docker_cli_swarm_test.go
+++ b/integration-cli/docker_cli_swarm_test.go
@@ -1308,7 +1308,7 @@ func (s *DockerSwarmSuite) TestSwarmRotateUnlockKey(c *check.C) {
 			// an issue sometimes prevents leader to be available right away
 			outs, err = d.Cmd("node", "ls")
 			if err != nil && retry < 5 {
-				if strings.Contains(err.Error(), "swarm does not have a leader") {
+				if strings.Contains(outs, "swarm does not have a leader") {
 					retry++
 					time.Sleep(3 * time.Second)
 					continue
@@ -1400,7 +1400,7 @@ func (s *DockerSwarmSuite) TestSwarmClusterRotateUnlockKey(c *check.C) {
 				// an issue sometimes prevents leader to be available right away
 				outs, err = d.Cmd("node", "ls")
 				if err != nil && retry < 5 {
-					if strings.Contains(err.Error(), "swarm does not have a leader") {
+					if strings.Contains(outs, "swarm does not have a leader") {
 						retry++
 						time.Sleep(3 * time.Second)
 						continue


### PR DESCRIPTION
## ~based on top of / depends on https://github.com/docker/engine/pull/353~ rebased

- _Partial_ backport of https://github.com/moby/moby/pull/39531 integration-cli: fix swarm tests flakiness
  - **skipped second commit (SwarmKit bump) as that requires backport to the SwarmKit bump_v19.03 branch**
  - addresses https://github.com/moby/moby/issues/36903 Flaky test: TestAPISwarmServicesCreate
  - addresses https://github.com/moby/moby/issues/34988 Flaky test: TestAPISwarmRaftQuorum
  - addresses https://github.com/moby/moby/issues/37132 Flaky test: TestServicePlugin, TestCreateServiceSecretFileMode
  - addresses https://github.com/moby/moby/issues/32673 Flaky test: TestAPISwarmLeaderElection
  - addresses https://github.com/moby/moby/issues/28240 Flaky test: DockerSwarmSuite.TestSwarmRotateUnlockKey
  - addresses https://github.com/moby/moby/issues/38885 Flaky test: DockerSwarmSuite.TestSwarmClusterRotateUnlockKey
- https://github.com/moby/moby/pull/39616 Fix TestSwarmClusterRotateUnlockKey
  - fixes https://github.com/moby/moby/issues/38885 Flaky test: DockerSwarmSuite.TestSwarmClusterRotateUnlockKey
  - addresses https://github.com/moby/moby/issues/39499 flaky DockerSwarmSuite tests
  - addresses https://github.com/moby/moby/issues/37306 EPIC: flaky tests
  - addresses https://github.com/moby/moby/issues/33041 flaky test: DockerSwarmSuite.TearDownTest on PowerPC


```
# (partial backport of) https://github.com/moby/moby/pull/39531 integration-cli: fix swarm tests flakiness
git cherry-pick -s -S -x 3df1095bbdc331d4effa5452d8aafd5aaead5789
# git cherry-pick -s -S -x 096a7afd37d688332b961994116a101d9f3ffab9 # SKIPPED, requires swarmkit backport to bump_v19.03 branch
git cherry-pick -s -S -x 52e0dfef9090fa3c6003115a2c82238b189ebe42

# https://github.com/docker/swarmkit/pull/2808 Fix flaky tests
git cherry-pick -s -S -x b79adac339173bf8bb6de6d0a061a97973c4b62b
```
