### PR TITLE
[18.09 backport] integration-cli: fix swarm tests flakiness

### DIFF
--- a/integration-cli/docker_cli_swarm_test.go
+++ b/integration-cli/docker_cli_swarm_test.go
@@ -1303,9 +1303,21 @@ func (s *DockerSwarmSuite) TestSwarmRotateUnlockKey(c *check.C) {
 
 		c.Assert(getNodeStatus(c, d), checker.Equals, swarm.LocalNodeStateActive)
 
-		outs, err = d.Cmd("node", "ls")
-		assert.NilError(c, err)
-		c.Assert(outs, checker.Not(checker.Contains), "Swarm is encrypted and needs to be unlocked")
+		retry := 0
+		for {
+			// an issue sometimes prevents leader to be available right away
+			outs, err = d.Cmd("node", "ls")
+			if err != nil && retry < 5 {
+				if strings.Contains(err.Error(), "swarm does not have a leader") {
+					retry++
+					time.Sleep(3 * time.Second)
+					continue
+				}
+			}
+			assert.NilError(c, err)
+			c.Assert(outs, checker.Not(checker.Contains), "Swarm is encrypted and needs to be unlocked")
+			break
+		}
 
 		unlockKey = newUnlockKey
 	}
@@ -1383,9 +1395,21 @@ func (s *DockerSwarmSuite) TestSwarmClusterRotateUnlockKey(c *check.C) {
 
 			c.Assert(getNodeStatus(c, d), checker.Equals, swarm.LocalNodeStateActive)
 
-			outs, err = d.Cmd("node", "ls")
-			c.Assert(err, checker.IsNil, check.Commentf("%s", outs))
-			c.Assert(outs, checker.Not(checker.Contains), "Swarm is encrypted and needs to be unlocked")
+			retry := 0
+			for {
+				// an issue sometimes prevents leader to be available right away
+				outs, err = d.Cmd("node", "ls")
+				if err != nil && retry < 5 {
+					if strings.Contains(err.Error(), "swarm does not have a leader") {
+						retry++
+						time.Sleep(3 * time.Second)
+						continue
+					}
+				}
+				c.Assert(err, checker.IsNil, check.Commentf("%s", outs))
+				c.Assert(outs, checker.Not(checker.Contains), "Swarm is encrypted and needs to be unlocked")
+				break
+			}
 		}
 
 		unlockKey = newUnlockKey

--- a/integration-cli/docker_cli_swarm_test.go
+++ b/integration-cli/docker_cli_swarm_test.go
@@ -1308,7 +1308,7 @@ func (s *DockerSwarmSuite) TestSwarmRotateUnlockKey(c *check.C) {
 			// an issue sometimes prevents leader to be available right away
 			outs, err = d.Cmd("node", "ls")
 			if err != nil && retry < 5 {
-				if strings.Contains(err.Error(), "swarm does not have a leader") {
+				if strings.Contains(outs, "swarm does not have a leader") {
 					retry++
 					time.Sleep(3 * time.Second)
 					continue
@@ -1400,7 +1400,7 @@ func (s *DockerSwarmSuite) TestSwarmClusterRotateUnlockKey(c *check.C) {
 				// an issue sometimes prevents leader to be available right away
 				outs, err = d.Cmd("node", "ls")
 				if err != nil && retry < 5 {
-					if strings.Contains(err.Error(), "swarm does not have a leader") {
+					if strings.Contains(outs, "swarm does not have a leader") {
 						retry++
 						time.Sleep(3 * time.Second)
 						continue

--- a/vendor.conf
+++ b/vendor.conf
@@ -130,7 +130,7 @@ github.com/containerd/ttrpc 2a805f71863501300ae1976d29f0454ae003e85a
 github.com/gogo/googleapis 08a7655d27152912db7aaf4f983275eaf8d128ef
 
 # cluster
-github.com/docker/swarmkit 142a73731c850daf24d32001aa2358b6ffe36eab # bump_v18.09 branch
+github.com/docker/swarmkit 5c86095cef3ff480e69486da50f18fd1b3a0de78 # bump_v18.09 branch
 github.com/gogo/protobuf v1.0.0
 github.com/cloudflare/cfssl 1.3.2
 github.com/fernet/fernet-go 1b2437bc582b3cfbb341ee5a29f8ef5b42912ff2

--- a/vendor/github.com/docker/swarmkit/agent/agent.go
+++ b/vendor/github.com/docker/swarmkit/agent/agent.go
@@ -575,7 +575,7 @@ func (a *Agent) nodeDescriptionWithHostname(ctx context.Context, tlsInfo *api.No
 
 	// Override hostname and TLS info
 	if desc != nil {
-		if a.config.Hostname != "" && desc != nil {
+		if a.config.Hostname != "" {
 			desc.Hostname = a.config.Hostname
 		}
 		desc.TLSInfo = tlsInfo

--- a/vendor/github.com/docker/swarmkit/agent/session.go
+++ b/vendor/github.com/docker/swarmkit/agent/session.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"errors"
+	"math"
 	"sync"
 	"time"
 
@@ -64,6 +65,7 @@ func newSession(ctx context.Context, agent *Agent, delay time.Duration, sessionI
 	cc, err := agent.config.ConnBroker.Select(
 		grpc.WithTransportCredentials(agent.config.Credentials),
 		grpc.WithTimeout(dispatcherRPCTimeout),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(math.MaxInt32)),
 	)
 
 	if err != nil {
@@ -136,7 +138,7 @@ func (s *session) start(ctx context.Context, description *api.NodeDescription) e
 	// `ctx` is done and hence fail to propagate the timeout error to the agent.
 	// If the error is not propogated to the agent, the agent will not close
 	// the session or rebuild a new session.
-	sessionCtx, cancelSession := context.WithCancel(ctx) // nolint: vet
+	sessionCtx, cancelSession := context.WithCancel(ctx) //nolint:govet
 
 	// Need to run Session in a goroutine since there's no way to set a
 	// timeout for an individual Recv call in a stream.
@@ -159,7 +161,7 @@ func (s *session) start(ctx context.Context, description *api.NodeDescription) e
 	select {
 	case err := <-errChan:
 		if err != nil {
-			return err // nolint: vet
+			return err //nolint:govet
 		}
 	case <-time.After(dispatcherRPCTimeout):
 		cancelSession()

--- a/vendor/github.com/docker/swarmkit/agent/worker.go
+++ b/vendor/github.com/docker/swarmkit/agent/worker.go
@@ -257,13 +257,11 @@ func reconcileTaskState(ctx context.Context, w *worker, assignments []*api.Assig
 	}
 
 	closeManager := func(tm *taskManager) {
-		go func(tm *taskManager) {
-			defer w.closers.Done()
-			// when a task is no longer assigned, we shutdown the task manager
-			if err := tm.Close(); err != nil {
-				log.G(ctx).WithError(err).Error("error closing task manager")
-			}
-		}(tm)
+		defer w.closers.Done()
+		// when a task is no longer assigned, we shutdown the task manager
+		if err := tm.Close(); err != nil {
+			log.G(ctx).WithError(err).Error("error closing task manager")
+		}
 
 		// make an attempt at removing. this is best effort. any errors will be
 		// retried by the reaper later.

--- a/vendor/github.com/docker/swarmkit/api/dispatcher.pb.go
+++ b/vendor/github.com/docker/swarmkit/api/dispatcher.pb.go
@@ -1664,7 +1664,7 @@ func (p *raftProxyDispatcherServer) Session(r *SessionRequest, stream Dispatcher
 			}
 			streamWrapper := Dispatcher_SessionServerWrapper{
 				Dispatcher_SessionServer: stream,
-				ctx: ctx,
+				ctx:                      ctx,
 			}
 			return p.local.Session(r, streamWrapper)
 		}
@@ -1785,7 +1785,7 @@ func (p *raftProxyDispatcherServer) Tasks(r *TasksRequest, stream Dispatcher_Tas
 			}
 			streamWrapper := Dispatcher_TasksServerWrapper{
 				Dispatcher_TasksServer: stream,
-				ctx: ctx,
+				ctx:                    ctx,
 			}
 			return p.local.Tasks(r, streamWrapper)
 		}
@@ -1836,7 +1836,7 @@ func (p *raftProxyDispatcherServer) Assignments(r *AssignmentsRequest, stream Di
 			}
 			streamWrapper := Dispatcher_AssignmentsServerWrapper{
 				Dispatcher_AssignmentsServer: stream,
-				ctx: ctx,
+				ctx:                          ctx,
 			}
 			return p.local.Assignments(r, streamWrapper)
 		}

--- a/vendor/github.com/docker/swarmkit/api/logbroker.pb.go
+++ b/vendor/github.com/docker/swarmkit/api/logbroker.pb.go
@@ -1335,7 +1335,7 @@ func (p *raftProxyLogsServer) SubscribeLogs(r *SubscribeLogsRequest, stream Logs
 			}
 			streamWrapper := Logs_SubscribeLogsServerWrapper{
 				Logs_SubscribeLogsServer: stream,
-				ctx: ctx,
+				ctx:                      ctx,
 			}
 			return p.local.SubscribeLogs(r, streamWrapper)
 		}
@@ -1458,7 +1458,7 @@ func (p *raftProxyLogBrokerServer) ListenSubscriptions(r *ListenSubscriptionsReq
 			}
 			streamWrapper := LogBroker_ListenSubscriptionsServerWrapper{
 				LogBroker_ListenSubscriptionsServer: stream,
-				ctx: ctx,
+				ctx:                                 ctx,
 			}
 			return p.local.ListenSubscriptions(r, streamWrapper)
 		}
@@ -1509,7 +1509,7 @@ func (p *raftProxyLogBrokerServer) PublishLogs(stream LogBroker_PublishLogsServe
 			}
 			streamWrapper := LogBroker_PublishLogsServerWrapper{
 				LogBroker_PublishLogsServer: stream,
-				ctx: ctx,
+				ctx:                         ctx,
 			}
 			return p.local.PublishLogs(streamWrapper)
 		}

--- a/vendor/github.com/docker/swarmkit/api/raft.pb.go
+++ b/vendor/github.com/docker/swarmkit/api/raft.pb.go
@@ -1746,7 +1746,7 @@ func (p *raftProxyRaftServer) StreamRaftMessage(stream Raft_StreamRaftMessageSer
 			}
 			streamWrapper := Raft_StreamRaftMessageServerWrapper{
 				Raft_StreamRaftMessageServer: stream,
-				ctx: ctx,
+				ctx:                          ctx,
 			}
 			return p.local.StreamRaftMessage(streamWrapper)
 		}

--- a/vendor/github.com/docker/swarmkit/api/types.pb.go
+++ b/vendor/github.com/docker/swarmkit/api/types.pb.go
@@ -594,7 +594,7 @@ var MaybeEncryptedRecord_Algorithm_name = map[int32]string{
 	2: "FERNET_AES_128_CBC",
 }
 var MaybeEncryptedRecord_Algorithm_value = map[string]int32{
-	"NONE": 0,
+	"NONE":                       0,
 	"SECRETBOX_SALSA20_POLY1305": 1,
 	"FERNET_AES_128_CBC":         2,
 }

--- a/vendor/github.com/docker/swarmkit/manager/dispatcher/dispatcher.go
+++ b/vendor/github.com/docker/swarmkit/manager/dispatcher/dispatcher.go
@@ -238,7 +238,7 @@ func (d *Dispatcher) Run(ctx context.Context) error {
 			if err != nil {
 				return err
 			}
-			if err == nil && len(clusters) == 1 {
+			if len(clusters) == 1 {
 				heartbeatPeriod, err := gogotypes.DurationFromProto(clusters[0].Spec.Dispatcher.HeartbeatPeriod)
 				if err == nil && heartbeatPeriod > 0 {
 					d.config.HeartbeatPeriod = heartbeatPeriod

--- a/vendor/github.com/docker/swarmkit/manager/drivers/provider.go
+++ b/vendor/github.com/docker/swarmkit/manager/drivers/provider.go
@@ -22,7 +22,7 @@ func (m *DriverProvider) NewSecretDriver(driver *api.Driver) (*SecretDriver, err
 	if m.pluginGetter == nil {
 		return nil, fmt.Errorf("plugin getter is nil")
 	}
-	if driver == nil && driver.Name == "" {
+	if driver == nil || driver.Name == "" {
 		return nil, fmt.Errorf("driver specification is nil")
 	}
 	// Search for the specified plugin

--- a/vendor/github.com/docker/swarmkit/manager/manager.go
+++ b/vendor/github.com/docker/swarmkit/manager/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"math"
 	"net"
 	"os"
 	"path/filepath"
@@ -758,6 +759,7 @@ func (m *Manager) updateKEK(ctx context.Context, cluster *api.Cluster) error {
 					func(addr string, timeout time.Duration) (net.Conn, error) {
 						return xnet.DialTimeoutLocal(addr, timeout)
 					}),
+				grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(math.MaxInt32)),
 			)
 			if err != nil {
 				logger.WithError(err).Error("failed to connect to local manager socket after locking the cluster")
@@ -1202,12 +1204,8 @@ func newIngressNetwork() *api.Network {
 			},
 			DriverConfig: &api.Driver{},
 			IPAM: &api.IPAMOptions{
-				Driver: &api.Driver{},
-				Configs: []*api.IPAMConfig{
-					{
-						Subnet: "10.255.0.0/16",
-					},
-				},
+				Driver:  &api.Driver{},
+				Configs: []*api.IPAMConfig{},
 			},
 		},
 	}

--- a/vendor/github.com/docker/swarmkit/manager/orchestrator/restart/restart.go
+++ b/vendor/github.com/docker/swarmkit/manager/orchestrator/restart/restart.go
@@ -508,20 +508,13 @@ func (r *Supervisor) Cancel(taskID string) {
 	<-delay.doneCh
 }
 
-// CancelAll aborts all pending restarts and waits for any instances of
-// StartNow that have already triggered to complete.
+// CancelAll aborts all pending restarts
 func (r *Supervisor) CancelAll() {
-	var cancelled []delayedStart
-
 	r.mu.Lock()
 	for _, delay := range r.delays {
 		delay.cancel()
 	}
 	r.mu.Unlock()
-
-	for _, delay := range cancelled {
-		<-delay.doneCh
-	}
 }
 
 // ClearServiceHistory forgets restart history related to a given service ID.

--- a/vendor/github.com/docker/swarmkit/manager/orchestrator/update/updater.go
+++ b/vendor/github.com/docker/swarmkit/manager/orchestrator/update/updater.go
@@ -501,7 +501,10 @@ func (u *Updater) removeOldTasks(ctx context.Context, batch *store.Batch, remove
 				return fmt.Errorf("task %s not found while trying to shut it down", original.ID)
 			}
 			if t.DesiredState > api.TaskStateRunning {
-				return fmt.Errorf("task %s was already shut down when reached by updater", original.ID)
+				return fmt.Errorf(
+					"task %s was already shut down when reached by updater (state: %v)",
+					original.ID, t.DesiredState,
+				)
 			}
 			t.DesiredState = api.TaskStateShutdown
 			return store.UpdateTask(tx, t)

--- a/vendor/github.com/docker/swarmkit/manager/scheduler/nodeinfo.go
+++ b/vendor/github.com/docker/swarmkit/manager/scheduler/nodeinfo.go
@@ -45,8 +45,8 @@ type NodeInfo struct {
 
 func newNodeInfo(n *api.Node, tasks map[string]*api.Task, availableResources api.Resources) NodeInfo {
 	nodeInfo := NodeInfo{
-		Node:  n,
-		Tasks: make(map[string]*api.Task),
+		Node:                      n,
+		Tasks:                     make(map[string]*api.Task),
 		ActiveTasksCountByService: make(map[string]int),
 		AvailableResources:        availableResources.Copy(),
 		usedHostPorts:             make(map[hostPortSpec]struct{}),

--- a/vendor/github.com/docker/swarmkit/node/node.go
+++ b/vendor/github.com/docker/swarmkit/node/node.go
@@ -6,6 +6,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"io/ioutil"
+	"math"
 	"net"
 	"os"
 	"path/filepath"
@@ -896,6 +897,7 @@ func (n *Node) initManagerConnection(ctx context.Context, ready chan<- struct{})
 	opts := []grpc.DialOption{
 		grpc.WithUnaryInterceptor(grpc_prometheus.UnaryClientInterceptor),
 		grpc.WithStreamInterceptor(grpc_prometheus.StreamClientInterceptor),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(math.MaxInt32)),
 	}
 	insecureCreds := credentials.NewTLS(&tls.Config{InsecureSkipVerify: true})
 	opts = append(opts, grpc.WithTransportCredentials(insecureCreds))


### PR DESCRIPTION
- _Partial_ backport of https://github.com/moby/moby/pull/39531 integration-cli: fix swarm tests flakiness
  - **skipped second commit (SwarmKit bump) as that requires backport to the SwarmKit bump_v18.09 branch**
  - addresses https://github.com/moby/moby/issues/36903 Flaky test: TestAPISwarmServicesCreate
  - addresses https://github.com/moby/moby/issues/34988 Flaky test: TestAPISwarmRaftQuorum
  - addresses https://github.com/moby/moby/issues/37132 Flaky test: TestServicePlugin, TestCreateServiceSecretFileMode
  - addresses https://github.com/moby/moby/issues/32673 Flaky test: TestAPISwarmLeaderElection
  - addresses https://github.com/moby/moby/issues/28240 Flaky test: DockerSwarmSuite.TestSwarmRotateUnlockKey
  - addresses https://github.com/moby/moby/issues/38885 Flaky test: DockerSwarmSuite.TestSwarmClusterRotateUnlockKey
- https://github.com/moby/moby/pull/39616 Fix TestSwarmClusterRotateUnlockKey
  - fixes https://github.com/moby/moby/issues/38885 Flaky test: DockerSwarmSuite.TestSwarmClusterRotateUnlockKey
  - addresses https://github.com/moby/moby/issues/39499 flaky DockerSwarmSuite tests
  - addresses https://github.com/moby/moby/issues/37306 EPIC: flaky tests
  - addresses https://github.com/moby/moby/issues/33041 flaky test: DockerSwarmSuite.TearDownTest on PowerPC


```
# (partial backport of) https://github.com/moby/moby/pull/39531 integration-cli: fix swarm tests flakiness
git cherry-pick -s -S -x 3df1095bbdc331d4effa5452d8aafd5aaead5789
# git cherry-pick -s -S -x 096a7afd37d688332b961994116a101d9f3ffab9 # SKIPPED, requires swarmkit backport to bump_v19.03 branch
git cherry-pick -s -S -x 52e0dfef9090fa3c6003115a2c82238b189ebe42

# https://github.com/docker/swarmkit/pull/2808 Fix flaky tests
git cherry-pick -s -S -x b79adac339173bf8bb6de6d0a061a97973c4b62b
```

### [18.09] bump SwarmKit 5c86095cef3ff480e69486da50f18fd1b3a0de78 (bump_v18.09)

full diff: https://github.com/docker/swarmkit/compare/142a73731c850daf24d32001aa2358b6ffe36eab...5c86095cef3ff480e69486da50f18fd1b3a0de78

- docker/swarmkit#2892 [18.09 backport] Remove hardcoded IPAM config subnet value for ingress network
    - backport of docker/swarmkit#2890 Remove hardcoded IPAM config subnet value for ingress network
    - fixes [ENGORC-2651](https://docker.atlassian.net/browse/ENGORC-2651)
- docker/swarmkit#2836 [18.09 backport] Switch to go 1.11
    - backport of docker/swarmkit#2752 Switch to go 1.11
- docker/swarmkit#2901 [18.09 backport] Bump to golang 1.12.9
    - backport of docker/swarmkit#2880 Bump to golang 1.12.9
- docker/swarmkit#2900 [18.09 backport] Fix update out of sequence and increase max recv gRPC message size for nodes and secrets
    - backport of docker/swarmkit#2762 Increased wait time on test utils WaitForCluster and WatchTaskCreate
    - backport of docker/swarmkit#2771 Allow using Configs as CredentialSpecs
        - **second commit only** (attempt to fix weirdly broken tests)
    - backport of docker/swarmkit#2808 Fix flaky tests
    - backport of docker/swarmkit#2866 Swap gometalinter for golangci-lint
    - backport of docker/swarmkit#2869 Increase max recv gRPC message size to initialize connection broker
        - related / similar to moby/moby#38103 / https://github.com/docker/engine/pull/102 cluster: set bigger grpc limit for array requests
        - related / similar to moby/moby#39306 Increase max recv gRPC message size for nodes and secrets
        - fixes docker/swarmkit#2733 Error generated when messages size is too big
    - backport of docker/swarmkit#2870 Fix update out of sequence

