### PR TITLE
[18.09 backport] Use correct `LOOP_CTL_GET_FREE` API in `pkg/loopback`

### DIFF
--- a/pkg/loopback/ioctl.go
+++ b/pkg/loopback/ioctl.go
@@ -9,11 +9,15 @@ import (
 )
 
 func ioctlLoopCtlGetFree(fd uintptr) (int, error) {
-	index, err := unix.IoctlGetInt(int(fd), LoopCtlGetFree)
-	if err != nil {
+	// The ioctl interface for /dev/loop-control (since Linux 3.1) is a bit
+	// off compared to what you'd expect: instead of writing an integer to a
+	// parameter pointer like unix.IoctlGetInt() expects, it returns the first
+	// available loop device index directly.
+	ioctlReturn, _, err := unix.Syscall(unix.SYS_IOCTL, fd, LoopCtlGetFree, 0)
+	if err != 0 {
 		return 0, err
 	}
-	return index, nil
+	return int(ioctlReturn), nil
 }
 
 func ioctlLoopSetFd(loopFd, sparseFd uintptr) error {


### PR DESCRIPTION
_backport of moby/moby#39801_

----

The `ioctl` interface for the `LOOP_CTL_GET_FREE` request on
`/dev/loop-control` is a little different from what `unix.IoctlGetInt`
expects: the first index is the returned status in `r1`, not an `int`
pointer as the first parameter.

Unfortunately we have to go a little lower level to get the appropriate
loop device index out, using `unix.Syscall` directly to read from
`r1`. Internally, the index is returned as a signed integer to match the
internal `ioctl` expectations of interpreting a negative signed integer
as an error at the userspace ABI boundary, so the direct interface of
`ioctlLoopCtlGetFree` can remain as-is.

[@kolyshkin: it still worked before this fix because of
/dev scan fallback in ioctlLoopCtlGetFree()]