### PR TITLE
[19.03 backport] Skip TestServiceRemoveKeepsIngressNetwork

### DIFF
--- a/integration/network/service_test.go
+++ b/integration/network/service_test.go
@@ -227,6 +227,8 @@ func TestServiceWithPredefinedNetwork(t *testing.T) {
 const ingressNet = "ingress"
 
 func TestServiceRemoveKeepsIngressNetwork(t *testing.T) {
+	t.Skip("FLAKY_TEST")
+
 	skip.If(t, testEnv.OSType == "windows")
 	defer setupTest(t)()
 	d := swarm.NewSwarm(t, testEnv)


### PR DESCRIPTION
Backport of https://github.com/moby/moby/pull/39453
Ref: https://github.com/moby/moby/issues/39426

This is a common flaky test that I have seen on multiple PRs.  It is not
consistent and should be skipped until it is fixed to be robust.  A
simple fix for the swarm tests is not easy as they all poll and have 1
billion timeouts in all the tests so a skip is valid here.
