### PR TITLE
[19.03 backport] Return "invalid parameter" when linking to non-existing container

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -24,6 +24,7 @@ import (
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/daemon/config"
 	"github.com/docker/docker/daemon/initlayer"
+	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/opts"
 	"github.com/docker/docker/pkg/containerfs"
 	"github.com/docker/docker/pkg/idtools"
@@ -1290,12 +1291,26 @@ func (daemon *Daemon) registerLinks(container *container.Container, hostConfig *
 		}
 		child, err := daemon.GetContainer(name)
 		if err != nil {
+			if errdefs.IsNotFound(err) {
+				// Trying to link to a non-existing container is not valid, and
+				// should return an "invalid parameter" error. Returning a "not
+				// found" error here would make the client report the container's
+				// image could not be found (see moby/moby#39823)
+				err = errdefs.InvalidParameter(err)
+			}
 			return errors.Wrapf(err, "could not get container for %s", name)
 		}
 		for child.HostConfig.NetworkMode.IsContainer() {
 			parts := strings.SplitN(string(child.HostConfig.NetworkMode), ":", 2)
 			child, err = daemon.GetContainer(parts[1])
 			if err != nil {
+				if errdefs.IsNotFound(err) {
+					// Trying to link to a non-existing container is not valid, and
+					// should return an "invalid parameter" error. Returning a "not
+					// found" error here would make the client report the container's
+					// image could not be found (see moby/moby#39823)
+					err = errdefs.InvalidParameter(err)
+				}
 				return errors.Wrapf(err, "Could not get container for %s", parts[1])
 			}
 		}


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/39852 to fix the regression in 19.03

fixes https://github.com/moby/moby/issues/39823
fixes https://github.com/docker/for-mac/issues/3871

Trying to link to a non-existing container is not valid, and should return an
"invalid parameter" (400) error. Returning a "not found" error in this situation
would make the client report the container's image could not be found.
