### PR TITLE
[19.03 backport] Windows: fix error-type for starting a running container

### DIFF
--- a/libcontainerd/local/local_windows.go
+++ b/libcontainerd/local/local_windows.go
@@ -607,7 +607,7 @@ func (c *client) Start(_ context.Context, id, _ string, withStdin bool, attachSt
 	case ctr == nil:
 		return -1, errors.WithStack(errdefs.NotFound(errors.New("no such container")))
 	case ctr.init != nil:
-		return -1, errors.WithStack(errdefs.Conflict(errors.New("container already started")))
+		return -1, errors.WithStack(errdefs.NotModified(errors.New("container already started")))
 	}
 
 	logger := c.logger.WithField("container", id)


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/39255

Trying to start a container that is already running is not an error condition, so a `304 Not Modified` should be returned instead of a `409 Conflict`.

relates to https://github.com/moby/moby/pull/39253

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```Markdown
* Windows: fix API status code when starting an already running container. Trying to start a container that is already running is not an error condition, so a `304 Not Modified` should be returned instead of a `409 Conflict`.
```

**- A picture of a cute animal (not mandatory but encouraged)**
