### PR TITLE
[18.09 backport] Send exec exit event on failures

### DIFF
--- a/daemon/monitor.go
+++ b/daemon/monitor.go
@@ -117,6 +117,7 @@ func (daemon *Daemon) ProcessEvent(id string, e libcontainerd.EventType, ei libc
 			return cpErr
 		}
 
+		exitCode := 127
 		if execConfig := c.ExecCommands.Get(ei.ProcessID); execConfig != nil {
 			ec := int(ei.ExitCode)
 			execConfig.Lock()
@@ -131,18 +132,14 @@ func (daemon *Daemon) ProcessEvent(id string, e libcontainerd.EventType, ei libc
 			// remove the exec command from the container's store only and not the
 			// daemon's store so that the exec command can be inspected.
 			c.ExecCommands.Delete(execConfig.ID, execConfig.Pid)
-			attributes := map[string]string{
-				"execID":   execConfig.ID,
-				"exitCode": strconv.Itoa(ec),
-			}
-			daemon.LogContainerEventWithAttributes(c, "exec_die", attributes)
-		} else {
-			logrus.WithFields(logrus.Fields{
-				"container": c.ID,
-				"exec-id":   ei.ProcessID,
-				"exec-pid":  ei.Pid,
-			}).Warn("Ignoring Exit Event, no such exec command found")
+
+			exitCode = ec
 		}
+		attributes := map[string]string{
+			"execID":   ei.ProcessID,
+			"exitCode": strconv.Itoa(exitCode),
+		}
+		daemon.LogContainerEventWithAttributes(c, "exec_die", attributes)
 	case libcontainerd.EventStart:
 		c.Lock()
 		defer c.Unlock()


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/39434

minor conflict because https://github.com/moby/moby/commit/85ad4b16c11425eaeace532bfce9029cfdcabe4b (https://github.com/moby/moby/pull/38541) is not in 18.09, and which moved the types from `libcontainerd` to `libcontainerdtypes`

fixes #39427

This always sends the exec exit events even when the exec fails to find
the binary.  A standard 127 exit status is sent in this situation.

