### PR TITLE
[19.03 backport] Ensure parent dir exists for mount cleanup file

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -1265,6 +1265,10 @@ func setupDaemonRootPropagation(cfg *config.Config) error {
 		return nil
 	}
 
+	if err := os.MkdirAll(filepath.Dir(cleanupFile), 0700); err != nil {
+		return errors.Wrap(err, "error creating dir to store mount cleanup file")
+	}
+
 	if err := ioutil.WriteFile(cleanupFile, nil, 0600); err != nil {
 		return errors.Wrap(err, "error writing file to signal mount cleanup on shutdown")
 	}


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/39496


While investigating a test failure, I found this in the logs:

```
time="2019-07-04T15:06:32.622506760Z" level=warning msg="Error while setting daemon root propagation, this is not generally critical but may cause some functionality to not work or fallback to less desirable behavior" dir=/go/src/github.com/docker/docker/bundles/test-integration/d1285b8250308/root error="error writing file to signal mount cleanup on shutdown: open /tmp/dxr/d1285b8250308/unmount-on-shutdown: no such file or directory"
```

This path is generated from the daemon's exec-root, which appears to not
exist yet. This change just makes sure it exists before we try to write
a file.
