### PR TITLE
[18.09 backport] Sleep before restarting event processing

### DIFF
--- a/libcontainerd/client_daemon.go
+++ b/libcontainerd/client_daemon.go
@@ -778,10 +778,16 @@ func (c *client) processEventStream(ctx context.Context, ns string) {
 				errStatus, ok := status.FromError(err)
 				if !ok || errStatus.Code() != codes.Canceled {
 					c.logger.WithError(err).Error("failed to get event")
-					go c.processEventStream(ctx, ns)
-				} else {
-					c.logger.WithError(ctx.Err()).Info("stopping event stream following graceful shutdown")
+
+					// rate limit
+					select {
+					case <-time.After(time.Second):
+						go c.processEventStream(ctx, ns)
+						return
+					case <-ctx.Done():
+					}
 				}
+				c.logger.WithError(ctx.Err()).Info("stopping event stream following graceful shutdown")
 			}
 			return
 		case ev = <-eventStream:


### PR DESCRIPTION
backport https://github.com/moby/moby/pull/39513

This prevents restarting event processing in a tight loop.
You can see this with the following steps:

```terminal
$ containerd &
$ dockerd --containerd=/run/containerd/containerd.sock &
$ pkill -9 containerd
```

At this point you will be spammed with logs such as:

```
ERRO[2019-07-12T22:29:37.318761400Z] failed to get event                           error="rpc error: code = Unavailable desc = all SubConns are in TransientFailure, latest connection error: connection error: desc = \"transport: Error while dialing dial unix /run/containerd/containerd.sock: connect: connection refused\"" module=libcontainerd namespace=plugins.moby
```

Without this change you can quickly end up with gigabytes of log data.
