### PR TITLE
[18.09 backport] atomic: patch 64bit alignment on 32bit systems

### DIFF
--- a/builder/builder-next/adapters/containerimage/pull.go
+++ b/builder/builder-next/adapters/containerimage/pull.go
@@ -810,9 +810,9 @@ type resolverCache struct {
 }
 
 type cachedResolver struct {
+	counter int64 // needs to be 64bit aligned for 32bit systems
 	timeout time.Time
 	remotes.Resolver
-	counter int64
 }
 
 func (cr *cachedResolver) Resolve(ctx context.Context, ref string) (name string, desc ocispec.Descriptor, err error) {


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/39543
fixes https://github.com/moby/buildkit/issues/1079

causes panic on armv7
