### PR TITLE
[19.03 backport] Bump Golang 1.12.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@
 #
 
 ARG CROSS="false"
-ARG GO_VERSION=1.12.8
+ARG GO_VERSION=1.12.9
 ARG DEBIAN_FRONTEND=noninteractive
 
 FROM golang:${GO_VERSION}-stretch AS base

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.12.8
+ARG GO_VERSION=1.12.9
 
 FROM golang:${GO_VERSION}-alpine AS base
 

--- a/Dockerfile.simple
+++ b/Dockerfile.simple
@@ -5,7 +5,7 @@
 
 # This represents the bare minimum required to build and test Docker.
 
-ARG GO_VERSION=1.12.8
+ARG GO_VERSION=1.12.9
 
 FROM golang:${GO_VERSION}-stretch
 

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -165,7 +165,7 @@ FROM microsoft/windowsservercore
 # Use PowerShell as the default shell
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ARG GO_VERSION=1.12.8
+ARG GO_VERSION=1.12.9
 
 # Environment variable notes:
 #  - GO_VERSION must be consistent with 'Dockerfile' used by Linux.


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/39755


**- What I did**
go1.12.9 (released 2019/08/15) includes fixes to the linker,
and the <code>os</code> and <code>math/big</code> packages.
See the <a href="https://github.com/golang/go/issues?q=milestone%3AGo1.12.9+label%3ACherryPickApproved">Go
1.12.9 milestone</a> on our issue tracker for details.

Full diff https://github.com/golang/go/compare/go1.12.8...go1.12.9



**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
bump golang 1.12.9

**- A picture of a cute animal (not mandatory but encouraged)**
