### PR TITLE
[18.09 backport] Update containerd to v1.2.9

### DIFF
--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-CONTAINERD_COMMIT=894b81a4b802e4eb2a91d1ce216b8817763c29fb # v1.2.6
+CONTAINERD_COMMIT=85f6aa58b8a3170aec9824568f7a31832878b603 # v1.2.7
 
 install_containerd() {
 	echo "Install containerd version $CONTAINERD_COMMIT"

--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-CONTAINERD_COMMIT=a4bc1d432a2c33aa2eed37f338dceabb93641310 # v1.2.8
+CONTAINERD_COMMIT=d50db0a42053864a270f648048f9a8b4f24eced3 # v1.2.9
 
 install_containerd() {
 	echo "Install containerd version $CONTAINERD_COMMIT"

--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-CONTAINERD_COMMIT=85f6aa58b8a3170aec9824568f7a31832878b603 # v1.2.7
+CONTAINERD_COMMIT=a4bc1d432a2c33aa2eed37f338dceabb93641310 # v1.2.8
 
 install_containerd() {
 	echo "Install containerd version $CONTAINERD_COMMIT"


### PR DESCRIPTION
## built on top of https://github.com/docker/engine/pull/283. First two commits are from that PR


backport of 

 - https://github.com/moby/moby/pull/39874 Update containerd to v1.2.9

Update containerd to v1.2.9. https://github.com/containerd/containerd/releases/tag/v1.2.9 

> The ninth patch release for containerd 1.2 provides a handful of bug fixes and an
update to the gRPC vendored codebase to include 3 CVE fixes provided in the upstream
v1.23.0 release of gRPC. Note that updating gRPC to the current release required small
changes to our core containerd codebase to match the upstream changes since gRPC v1.12.0.
These changes have been backported from containerd's master branch, as well as a
similar small change in ttrpc, requiring that package's vendoring to be updated.

> In addition to the gRPC update to include CVE fixes, fixes were made to correct a
container's default Unix environment (introduced in 1.2.8), a small list of CRI plugin
fixes, as well as fixes for registry interactions where Docker-Content-Digest is not
returned (e.g. GitHub Package Registry), and a tar archive modification time bug found
by the buildkit maintainers. A fix to the zfs snapshotter was also included via a
re-vendoring of containerd's zfs import. More notes on these fixes are found below.
