### PR TITLE
[19.03 backport] distribution: modify warning logic when pulling v2 schema1 manifests

### DIFF
--- a/distribution/push_v2.go
+++ b/distribution/push_v2.go
@@ -188,7 +188,7 @@ func (p *v2Pusher) pushV2Tag(ctx context.Context, ref reference.NamedTagged, id 
 
 		logrus.Warnf("failed to upload schema2 manifest: %v - falling back to schema1", err)
 
-		msg := schema1DeprecationMessage(ref)
+		msg := fmt.Sprintf("[DEPRECATION NOTICE] registry v2 schema1 support will be removed in an upcoming release. Please contact admins of the %s registry NOW to avoid future disruption. More information at https://docs.docker.com/registry/spec/deprecated-schema-v1/", reference.Domain(ref))
 		logrus.Warn(msg)
 		progress.Message(p.config.ProgressOutput, "", msg)
 

--- a/distribution/registry.go
+++ b/distribution/registry.go
@@ -156,7 +156,3 @@ func (th *existingTokenHandler) AuthorizeRequest(req *http.Request, params map[s
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", th.token))
 	return nil
 }
-
-func schema1DeprecationMessage(ref reference.Named) string {
-	return fmt.Sprintf("[DEPRECATION NOTICE] registry v2 schema1 support will be removed in an upcoming release. Please contact admins of the %s registry NOW to avoid future disruption.", reference.Domain(ref))
-}


### PR DESCRIPTION
Clean cherry-pick of https://github.com/moby/moby/pull/39736