### PR TITLE
[19.03] Jenkinsfile: ensure all containers are cleaned up

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -662,6 +662,8 @@ pipeline {
                             sh '''
                             echo "Ensuring container killed."
                             docker rm -vf docker-pr$BUILD_NUMBER || true
+                            cids=$(docker ps -aq -f name=docker-pr${BUILD_NUMBER}-*)
+                            [ -n "$cids" ] && docker rm -vf $cids || true
                             '''
 
                             sh '''


### PR DESCRIPTION
Clean cherry-pick of f470698:
```
$ git cherry-pick -s -x f470698c2c10c2382080fab34f83088450fabdd6
[clean 4b5c535be9] Jenkinsfile: ensure all containers are cleaned up
 Author: Tibor Vass <tibor@docker.com>
 Date: Wed Sep 18 21:47:58 2019 +0000
 1 file changed, 2 insertions(+)
```