### PR TITLE
[19.03] vendor: update buildkit for 19.03

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -27,8 +27,8 @@ github.com/imdario/mergo                            7c29201646fa3de8506f70121347
 golang.org/x/sync                                   e225da77a7e68af35c70ccbf71af2b83e6acac3c
 
 # buildkit
-github.com/moby/buildkit                            588c73e1e4f0f3d7d3738abaaa7cf8026064b33e
-github.com/tonistiigi/fsutil                        3bbb99cdbd76619ab717299830c60f6f2a533a6b
+github.com/moby/buildkit                            ae10b292fefb00e0fbf9fecd1419c5f252e58895
+github.com/tonistiigi/fsutil                        3d2716dd0a4d06ff854241c7e8b6f3f904e1719f
 github.com/grpc-ecosystem/grpc-opentracing          8e809c8a86450a29b90dcc9efbf062d0fe6d9746
 github.com/opentracing/opentracing-go               1361b9cd60be79c4c3a7fa9841b3c132e40066a7
 github.com/google/shlex                             6f45313302b9c56850fc17f99e40caebce98c716
@@ -125,7 +125,7 @@ github.com/containerd/fifo                          a9fb20d87448d386e6d50b1f2e1f
 github.com/containerd/continuity                    aaeac12a7ffcd198ae25440a9dff125c2e2703a7
 github.com/containerd/cgroups                       4994991857f9b0ae8dc439551e8bebdbb4bf66c1
 github.com/containerd/console                       0650fd9eeb50bab4fc99dceb9f2e14cf58f36e7f
-github.com/containerd/go-runc                       7d11b49dc0769f6dbb0d1b19f3d48524d1bad9ad
+github.com/containerd/go-runc                       e029b79d8cda8374981c64eba71f28ec38e5526f
 github.com/containerd/typeurl                       2a93cfde8c20b23de8eb84a5adbc234ddf7a9e8d
 github.com/containerd/ttrpc                         699c4e40d1e7416e08bf7019c7ce2e9beced4636
 github.com/gogo/googleapis                          d31c731455cb061f42baff3bda55bad0118b126b # v1.2.0

--- a/vendor/github.com/containerd/go-runc/runc.go
+++ b/vendor/github.com/containerd/go-runc/runc.go
@@ -275,7 +275,11 @@ func (r *Runc) Run(context context.Context, id, bundle string, opts *CreateOpts)
 	if err != nil {
 		return -1, err
 	}
-	return Monitor.Wait(cmd, ec)
+	status, err := Monitor.Wait(cmd, ec)
+	if err == nil && status != 0 {
+		err = fmt.Errorf("%s did not terminate sucessfully", cmd.Args[0])
+	}
+	return status, err
 }
 
 type DeleteOpts struct {
@@ -570,7 +574,11 @@ func (r *Runc) Restore(context context.Context, id, bundle string, opts *Restore
 			}
 		}
 	}
-	return Monitor.Wait(cmd, ec)
+	status, err := Monitor.Wait(cmd, ec)
+	if err == nil && status != 0 {
+		err = fmt.Errorf("%s did not terminate sucessfully", cmd.Args[0])
+	}
+	return status, err
 }
 
 // Update updates the current container with the provided resource spec

--- a/vendor/github.com/moby/buildkit/executor/runcexecutor/executor.go
+++ b/vendor/github.com/moby/buildkit/executor/runcexecutor/executor.go
@@ -293,12 +293,11 @@ func (w *runcExecutor) Exec(ctx context.Context, meta executor.Meta, root cache.
 		NoPivot: w.noPivot,
 	})
 	close(done)
-	if err != nil {
-		return err
-	}
 
-	if status != 0 {
-		err := errors.Errorf("exit code: %d", status)
+	if status != 0 || err != nil {
+		if err == nil {
+			err = errors.Errorf("exit code: %d", status)
+		}
 		select {
 		case <-ctx.Done():
 			return errors.Wrapf(ctx.Err(), err.Error())

--- a/vendor/github.com/moby/buildkit/go.mod
+++ b/vendor/github.com/moby/buildkit/go.mod
@@ -10,10 +10,10 @@ require (
 	github.com/containerd/cgroups v0.0.0-20190226200435-dbea6f2bd416 // indirect
 	github.com/containerd/console v0.0.0-20181022165439-0650fd9eeb50
 	github.com/containerd/containerd v1.3.0-0.20190507210959-7c1e88399ec0
-	github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc
+	github.com/containerd/continuity v0.0.0-20190827140505-75bee3e2ccb6
 	github.com/containerd/fifo v0.0.0-20180307165137-3d5202aec260 // indirect
 	github.com/containerd/go-cni v0.0.0-20190610170741-5a4663dad645
-	github.com/containerd/go-runc v0.0.0-20180907222934-5a6d9f37cfa3
+	github.com/containerd/go-runc v0.0.0-20190911050354-e029b79d8cda
 	github.com/containerd/ttrpc v0.0.0-20190411181408-699c4e40d1e7 // indirect
 	github.com/containerd/typeurl v0.0.0-20180627222232-a93fcdb778cd // indirect
 	github.com/containernetworking/cni v0.6.1-0.20180218032124-142cde0c766c // indirect
@@ -53,7 +53,7 @@ require (
 	github.com/sirupsen/logrus v1.3.0
 	github.com/stretchr/testify v1.3.0
 	github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2 // indirect
-	github.com/tonistiigi/fsutil v0.0.0-20190327153851-3bbb99cdbd76
+	github.com/tonistiigi/fsutil v0.0.0-20190819224149-3d2716dd0a4d
 	github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea
 	github.com/uber/jaeger-client-go v0.0.0-20180103221425-e02c85f9069e
 	github.com/uber/jaeger-lib v1.2.1 // indirect

--- a/vendor/github.com/moby/buildkit/session/sshforward/ssh.go
+++ b/vendor/github.com/moby/buildkit/session/sshforward/ssh.go
@@ -49,7 +49,7 @@ func (s *server) run(ctx context.Context, l net.Listener, id string) error {
 				return err
 			}
 
-			go Copy(ctx, conn, stream)
+			go Copy(ctx, conn, stream, stream.CloseSend)
 		}
 	})
 

--- a/vendor/github.com/moby/buildkit/solver/edge.go
+++ b/vendor/github.com/moby/buildkit/solver/edge.go
@@ -177,6 +177,9 @@ func (e *edge) finishIncoming(req pipe.Sender) {
 
 // updateIncoming updates the current value of incoming pipe request
 func (e *edge) updateIncoming(req pipe.Sender) {
+	if debugScheduler {
+		logrus.Debugf("updateIncoming %s %#v desired=%s", e.edge.Vertex.Name(), e.edgeState, req.Request().Payload.(*edgeRequest).desiredState)
+	}
 	req.Update(&e.edgeState)
 }
 

--- a/vendor/github.com/moby/buildkit/solver/internal/pipe/pipe.go
+++ b/vendor/github.com/moby/buildkit/solver/internal/pipe/pipe.go
@@ -11,11 +11,15 @@ import (
 type channel struct {
 	OnSendCompletion func()
 	value            atomic.Value
-	lastValue        interface{}
+	lastValue        *wrappedValue
+}
+
+type wrappedValue struct {
+	value interface{}
 }
 
 func (c *channel) Send(v interface{}) {
-	c.value.Store(v)
+	c.value.Store(&wrappedValue{value: v})
 	if c.OnSendCompletion != nil {
 		c.OnSendCompletion()
 	}
@@ -23,11 +27,11 @@ func (c *channel) Send(v interface{}) {
 
 func (c *channel) Receive() (interface{}, bool) {
 	v := c.value.Load()
-	if c.lastValue == v {
+	if v == nil || v.(*wrappedValue) == c.lastValue {
 		return nil, false
 	}
-	c.lastValue = v
-	return v, true
+	c.lastValue = v.(*wrappedValue)
+	return v.(*wrappedValue).value, true
 }
 
 type Pipe struct {

--- a/vendor/github.com/moby/buildkit/solver/llbsolver/bridge.go
+++ b/vendor/github.com/moby/buildkit/solver/llbsolver/bridge.go
@@ -54,7 +54,7 @@ func (b *llbBridge) Solve(ctx context.Context, req frontend.SolveRequest) (res *
 			}
 		}
 		if prevCm, ok := b.cms[cmId]; !ok {
-			func(cmId string) {
+			func(cmId string, im gw.CacheOptionsEntry) {
 				cm = newLazyCacheManager(cmId, func() (solver.CacheManager, error) {
 					var cmNew solver.CacheManager
 					if err := inVertexContext(b.builder.Context(ctx), "importing cache manifest from "+cmId, "", func(ctx context.Context) error {
@@ -74,7 +74,7 @@ func (b *llbBridge) Solve(ctx context.Context, req frontend.SolveRequest) (res *
 					}
 					return cmNew, nil
 				})
-			}(cmId)
+			}(cmId, im)
 			b.cms[cmId] = cm
 		} else {
 			cm = prevCm

--- a/vendor/github.com/tonistiigi/fsutil/copy/copy.go
+++ b/vendor/github.com/tonistiigi/fsutil/copy/copy.go
@@ -329,21 +329,6 @@ func ensureEmptyFileTarget(dst string) error {
 	return os.Remove(dst)
 }
 
-func copyFile(source, target string) error {
-	src, err := os.Open(source)
-	if err != nil {
-		return errors.Wrapf(err, "failed to open source %s", source)
-	}
-	defer src.Close()
-	tgt, err := os.Create(target)
-	if err != nil {
-		return errors.Wrapf(err, "failed to open target %s", target)
-	}
-	defer tgt.Close()
-
-	return copyFileContent(tgt, src)
-}
-
 func containsWildcards(name string) bool {
 	isWindows := runtime.GOOS == "windows"
 	for i := 0; i < len(name); i++ {

--- a/vendor/github.com/tonistiigi/fsutil/copy/copy_darwin.go
+++ b/vendor/github.com/tonistiigi/fsutil/copy/copy_darwin.go
@@ -1,0 +1,84 @@
+// +build darwin
+
+package fs
+
+import (
+	"io"
+	"os"
+	"syscall"
+	"unsafe"
+
+	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
+)
+
+// <sys/clonefile.h
+// int clonefileat(int, const char *, int, const char *, uint32_t) __OSX_AVAILABLE(10.12) __IOS_AVAILABLE(10.0) __TVOS_AVAILABLE(10.0) __WATCHOS_AVAILABLE(3.0);
+
+const CLONE_NOFOLLOW = 0x0001    /* Don't follow symbolic links */
+const CLONE_NOOWNERCOPY = 0x0002 /* Don't copy ownership information from */
+
+func copyFile(source, target string) error {
+	if err := clonefile(source, target); err != nil {
+		if err != unix.EINVAL {
+			return err
+		}
+	} else {
+		return nil
+	}
+
+	src, err := os.Open(source)
+	if err != nil {
+		return errors.Wrapf(err, "failed to open source %s", source)
+	}
+	defer src.Close()
+	tgt, err := os.Create(target)
+	if err != nil {
+		return errors.Wrapf(err, "failed to open target %s", target)
+	}
+	defer tgt.Close()
+
+	return copyFileContent(tgt, src)
+}
+
+func copyFileContent(dst, src *os.File) error {
+	buf := bufferPool.Get().(*[]byte)
+	_, err := io.CopyBuffer(dst, src, *buf)
+	bufferPool.Put(buf)
+
+	return err
+}
+
+// errnoErr returns common boxed Errno values, to prevent
+// allocations at runtime.
+func errnoErr(e syscall.Errno) error {
+	switch e {
+	case 0:
+		return nil
+	case unix.EAGAIN:
+		return syscall.EAGAIN
+	case unix.EINVAL:
+		return syscall.EINVAL
+	case unix.ENOENT:
+		return syscall.ENOENT
+	}
+	return e
+}
+
+func clonefile(src, dst string) (err error) {
+	var _p0, _p1 *byte
+	_p0, err = unix.BytePtrFromString(src)
+	if err != nil {
+		return
+	}
+	_p1, err = unix.BytePtrFromString(dst)
+	if err != nil {
+		return
+	}
+	fdcwd := unix.AT_FDCWD
+	_, _, e1 := unix.Syscall6(unix.SYS_CLONEFILEAT, uintptr(fdcwd), uintptr(unsafe.Pointer(_p0)), uintptr(fdcwd), uintptr(unsafe.Pointer(_p1)), uintptr(CLONE_NOFOLLOW), 0)
+	if e1 != 0 {
+		err = errnoErr(e1)
+	}
+	return
+}

--- a/vendor/github.com/tonistiigi/fsutil/copy/copy_linux.go
+++ b/vendor/github.com/tonistiigi/fsutil/copy/copy_linux.go
@@ -52,6 +52,21 @@ func (c *copier) copyFileInfo(fi os.FileInfo, name string) error {
 	return nil
 }
 
+func copyFile(source, target string) error {
+	src, err := os.Open(source)
+	if err != nil {
+		return errors.Wrapf(err, "failed to open source %s", source)
+	}
+	defer src.Close()
+	tgt, err := os.Create(target)
+	if err != nil {
+		return errors.Wrapf(err, "failed to open target %s", target)
+	}
+	defer tgt.Close()
+
+	return copyFileContent(tgt, src)
+}
+
 func copyFileContent(dst, src *os.File) error {
 	st, err := src.Stat()
 	if err != nil {

--- a/vendor/github.com/tonistiigi/fsutil/copy/copy_unix.go
+++ b/vendor/github.com/tonistiigi/fsutil/copy/copy_unix.go
@@ -3,7 +3,6 @@
 package fs
 
 import (
-	"io"
 	"os"
 	"syscall"
 
@@ -49,14 +48,6 @@ func (c *copier) copyFileInfo(fi os.FileInfo, name string) error {
 		}
 	}
 	return nil
-}
-
-func copyFileContent(dst, src *os.File) error {
-	buf := bufferPool.Get().(*[]byte)
-	_, err := io.CopyBuffer(dst, src, *buf)
-	bufferPool.Put(buf)
-
-	return err
 }
 
 func copyDevice(dst string, fi os.FileInfo) error {

--- a/vendor/github.com/tonistiigi/fsutil/copy/copy_windows.go
+++ b/vendor/github.com/tonistiigi/fsutil/copy/copy_windows.go
@@ -17,6 +17,21 @@ func (c *copier) copyFileInfo(fi os.FileInfo, name string) error {
 	return nil
 }
 
+func copyFile(source, target string) error {
+	src, err := os.Open(source)
+	if err != nil {
+		return errors.Wrapf(err, "failed to open source %s", source)
+	}
+	defer src.Close()
+	tgt, err := os.Create(target)
+	if err != nil {
+		return errors.Wrapf(err, "failed to open target %s", target)
+	}
+	defer tgt.Close()
+
+	return copyFileContent(tgt, src)
+}
+
 func copyFileContent(dst, src *os.File) error {
 	buf := bufferPool.Get().(*[]byte)
 	_, err := io.CopyBuffer(dst, src, *buf)

--- a/vendor/github.com/tonistiigi/fsutil/stat.go
+++ b/vendor/github.com/tonistiigi/fsutil/stat.go
@@ -49,6 +49,9 @@ func mkstat(path, relpath string, fi os.FileInfo, inodemap map[uint64]string) (*
 		stat.Mode = noPermPart | permPart
 	}
 
+	// Clear the socket bit since archive/tar.FileInfoHeader does not handle it
+	stat.Mode &^= uint32(os.ModeSocket)
+
 	return stat, nil
 }
 


### PR DESCRIPTION
Fix socket handling https://github.com/moby/buildkit/pull/1144
session: release forwarded ssh socket connection per connection https://github.com/moby/buildkit/pull/1150
llbsolver: fix error on multiple cache importers https://github.com/moby/buildkit/pull/1156
http: Handle missing but unambiguous ETags in response https://github.com/moby/buildkit/pull/1159
solver: fix pipe signaling on incoming updates https://github.com/moby/buildkit/pull/1166
vendor: update go-runc to e029b79d https://github.com/moby/buildkit/pull/1168

https://github.com/moby/buildkit/pull/1178

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>
