### PR TITLE
[19.03 backport] Add TC to check dynamic subnet for ingress network

### DIFF
--- a/integration/network/service_test.go
+++ b/integration/network/service_test.go
@@ -417,6 +417,12 @@ func TestServiceWithDefaultAddressPoolInit(t *testing.T) {
 	assert.NilError(t, err)
 	t.Logf("%s: NetworkInspect: %+v", t.Name(), out)
 	assert.Assert(t, len(out.IPAM.Config) > 0)
+	assert.Equal(t, out.IPAM.Config[0].Subnet, "20.20.1.0/24")
+
+	// Also inspect ingress network and make sure its in the same subnet
+	out, err = cli.NetworkInspect(ctx, "ingress", types.NetworkInspectOptions{Verbose: true})
+	assert.NilError(t, err)
+	assert.Assert(t, len(out.IPAM.Config) > 0)
 	assert.Equal(t, out.IPAM.Config[0].Subnet, "20.20.0.0/24")
 
 	err = cli.ServiceRemove(ctx, serviceID)

--- a/vendor.conf
+++ b/vendor.conf
@@ -128,7 +128,7 @@ github.com/containerd/ttrpc                         92c8520ef9f86600c650dd540266
 github.com/gogo/googleapis                          d31c731455cb061f42baff3bda55bad0118b126b # v1.2.0
 
 # cluster
-github.com/docker/swarmkit                          bbe341867eae1615faf8a702ec05bfe986e73e06 # bump_v19.03 branch
+github.com/docker/swarmkit                          f35d9100f2c6ac810cc8d7de6e8f93dcc7a42d29 # bump_v19.03 branch
 github.com/gogo/protobuf                            ba06b47c162d49f2af050fb4c75bcbc86a159d5c # v1.2.1
 github.com/golang/protobuf                          aa810b61a9c79d51363740d207bb46cf8e620ed5 # v1.2.0
 github.com/cloudflare/cfssl                         5d63dbd981b5c408effbb58c442d54761ff94fbd # 1.3.2

--- a/vendor/github.com/docker/swarmkit/manager/manager.go
+++ b/vendor/github.com/docker/swarmkit/manager/manager.go
@@ -1224,12 +1224,8 @@ func newIngressNetwork() *api.Network {
 			},
 			DriverConfig: &api.Driver{},
 			IPAM: &api.IPAMOptions{
-				Driver: &api.Driver{},
-				Configs: []*api.IPAMConfig{
-					{
-						Subnet: "10.255.0.0/16",
-					},
-				},
+				Driver:  &api.Driver{},
+				Configs: []*api.IPAMConfig{},
 			},
 		},
 	}


### PR DESCRIPTION
## based on top of ~https://github.com/docker/engine/pull/281 and~ https://github.com/docker/engine/pull/376

depends on:

- [ ]  https://github.com/moby/moby/pull/39966 Add TC to check dynamic subnet for ingress network
- [x] https://github.com/docker/engine/pull/281 [19.03 backport] Integration: change signatures to fix golint warnings
- [x] https://github.com/docker/engine/pull/376 [19.03 backport] Fix flaky TestServiceWithDefaultAddressPoolInit



closes https://github.com/docker/engine/pull/375 (which is an alternative for this one)

### Revert https://github.com/docker/engine/pull/375
brings back https://github.com/docker/engine/pull/369

full diff: https://github.com/docker/swarmkit/compare/bbe341867eae1615faf8a702ec05bfe986e73e06...f35d9100f2c6ac810cc8d7de6e8f93dcc7a42d29

changes included:

- docker/swarmkit#2891 [19.03 backport] Remove hardcoded IPAM config subnet value for ingress network
  - backport of docker/swarmkit#2890 Remove hardcoded IPAM config subnet value for ingress network
  - fixes [ENGCORE-1028] Specifying --default-addr-pool for docker swarm init is not picked up by ingress network



[ENGCORE-1028]: https://docker.atlassian.net/browse/ENGCORE-1028



### Backport of https://github.com/moby/moby/pull/39966 for 19.03

To fix CI being red after merging https://github.com/docker/engine/pull/369 (effectively a backport of https://github.com/moby/moby/pull/39953)


Marked as "WIP", because upstream isn't merged yet