### PR TITLE
[19.03] Revert "bump swarmkit to f35d9100f2c6ac810cc8d7de6e8f93dcc7a42d29"

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -131,7 +131,7 @@ github.com/containerd/ttrpc                         699c4e40d1e7416e08bf7019c7ce
 github.com/gogo/googleapis                          d31c731455cb061f42baff3bda55bad0118b126b # v1.2.0
 
 # cluster
-github.com/docker/swarmkit                          f35d9100f2c6ac810cc8d7de6e8f93dcc7a42d29 # bump_v19.03 branch
+github.com/docker/swarmkit                          bbe341867eae1615faf8a702ec05bfe986e73e06 # bump_v19.03 branch
 github.com/gogo/protobuf                            ba06b47c162d49f2af050fb4c75bcbc86a159d5c # v1.2.1
 github.com/cloudflare/cfssl                         5d63dbd981b5c408effbb58c442d54761ff94fbd # 1.3.2
 github.com/fernet/fernet-go                         1b2437bc582b3cfbb341ee5a29f8ef5b42912ff2

--- a/vendor/github.com/docker/swarmkit/manager/manager.go
+++ b/vendor/github.com/docker/swarmkit/manager/manager.go
@@ -1224,8 +1224,12 @@ func newIngressNetwork() *api.Network {
 			},
 			DriverConfig: &api.Driver{},
 			IPAM: &api.IPAMOptions{
-				Driver:  &api.Driver{},
-				Configs: []*api.IPAMConfig{},
+				Driver: &api.Driver{},
+				Configs: []*api.IPAMConfig{
+					{
+						Subnet: "10.255.0.0/16",
+					},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
Alternative to https://github.com/docker/engine/pull/374

This reverts commit 02465c9f9da4064211d0f7e56a8c93a567589713 (https://github.com/docker/engine/pull/369)
to fix CI being red after merging https://github.com/docker/engine/pull/369 (effectively a backport of https://github.com/moby/moby/pull/39953) without making changes to the test (done in https://github.com/moby/moby/pull/39966)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
