### PR TITLE
[18.09 backport] Fix unmount redeclaration on darwin

### DIFF
--- a/pkg/mount/mounter_unsupported.go
+++ b/pkg/mount/mounter_unsupported.go
@@ -5,7 +5,3 @@ package mount // import "github.com/docker/docker/pkg/mount"
 func mount(device, target, mType string, flag uintptr, data string) error {
 	panic("Not implemented")
 }
-
-func unmount(target string, flag int) error {
-	panic("Not implemented")
-}

--- a/pkg/mount/unmount_unsupported.go
+++ b/pkg/mount/unmount_unsupported.go
@@ -1,0 +1,7 @@
+// +build windows
+
+package mount // import "github.com/docker/docker/pkg/mount"
+
+func unmount(target string, flag int) error {
+	panic("Not implemented")
+}


### PR DESCRIPTION
Backport of https://github.com/moby/moby/pull/38372 to 18.09. Clean cherry-pick.

Needed for https://github.com/docker/cli/pull/2100

Original description follows.

---

Fix unmount redeclaration on darwin in github.com/docker/docker/pkg/mount