### PR TITLE
[18.09 backport] update containerd 1.2.10, runc v1.0.0-rc8-92-g84373aaa (CVE-2019-16884)

### DIFF
--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-CONTAINERD_COMMIT=894b81a4b802e4eb2a91d1ce216b8817763c29fb # v1.2.6
+CONTAINERD_COMMIT=85f6aa58b8a3170aec9824568f7a31832878b603 # v1.2.7
 
 install_containerd() {
 	echo "Install containerd version $CONTAINERD_COMMIT"

--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-CONTAINERD_COMMIT=d50db0a42053864a270f648048f9a8b4f24eced3 # v1.2.9
+CONTAINERD_COMMIT=b34a5c8af56e510852c35414db4c1f4fa6172339 # v1.2.10
 
 install_containerd() {
 	echo "Install containerd version $CONTAINERD_COMMIT"

--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-CONTAINERD_COMMIT=a4bc1d432a2c33aa2eed37f338dceabb93641310 # v1.2.8
+CONTAINERD_COMMIT=d50db0a42053864a270f648048f9a8b4f24eced3 # v1.2.9
 
 install_containerd() {
 	echo "Install containerd version $CONTAINERD_COMMIT"

--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-CONTAINERD_COMMIT=85f6aa58b8a3170aec9824568f7a31832878b603 # v1.2.7
+CONTAINERD_COMMIT=a4bc1d432a2c33aa2eed37f338dceabb93641310 # v1.2.8
 
 install_containerd() {
 	echo "Install containerd version $CONTAINERD_COMMIT"

--- a/hack/dockerfile/install/runc.installer
+++ b/hack/dockerfile/install/runc.installer
@@ -4,7 +4,7 @@
 # The version of runc should match the version that is used by the containerd
 # version that is used. If you need to update runc, open a pull request in
 # the containerd project first, and update both after that is merged.
-RUNC_COMMIT=425e105d5a03fabd737a126ad93d62a9eeede87f # v1.0.0-rc8
+RUNC_COMMIT=3e425f80a8c931f88e6d94a8c831b9d5aa481657 # v1.0.0-rc8-92-g84373aaa
 
 install_runc() {
 	# If using RHEL7 kernels (3.10.0 el7), disable kmem accounting/limiting


### PR DESCRIPTION
backports of:

- https://github.com/moby/moby/pull/39995 Update containerd to v1.2.10
- https://github.com/moby/moby/pull/40001 Update runc to v1.0.0-rc8-92-g84373aaa (CVE-2019-16884)
  - **only the first commit**


closes https://github.com/docker/engine/pull/283 [18.09 backport] Update containerd to v1.2.8
closes https://github.com/docker/engine/pull/367 [18.09 backport] Update containerd to v1.2.9


### Update containerd to v1.2.10

>The tenth patch release for containerd 1.2 includes only one main bug fix in the
CRI plugin, but includes updated vendors/build runtimes that fix 2 reported CVEs in
runc and the Golang 1.12 runtime respectively.
>## Notable Updates
>* Update the runc vendor to capture the fix for CVE-2019-16884. Fixed by PR #3685
>    - More details on the runc CVE in opencontainers/runc#2128, fixed by opencontainers/runc#2129

>* Update Golang runtime to 1.12.10 to handle CVE-2019-16276. More detail on the Golang CVE available in golang/go#34540
>* CRI fixes:
>    - Fix a bug that the default UNIX path is not in the default OCI config via the CRI plugin. Reported in containerd/cri#1279 and fixed by containerd/cri#1283


### Update runc to v1.0.0-rc8-92-g84373aaa (CVE-2019-16884)

full diff: https://github.com/opencontainers/runc/compare/v1.0.0-rc8...3e425f80a8c931f88e6d94a8c831b9d5aa481657

  - opencontainers/runc#2010 criu image path permission error when checkpoint rootless container
  - opencontainers/runc#2028 Update to Go 1.12 and drop obsolete versions
  - opencontainers/runc#2029 Update dependencies
  - opencontainers/runc#2034 Support for logging from children processes
  - opencontainers/runc#2035 specconv: always set "type: bind" in case of MS_BIND
  - opencontainers/runc#2038 `r.destroy` can defer exec in `runner.run` method
  - opencontainers/runc#2041 Change the permissions of the notify listener socket to rwx for everyone
  - opencontainers/runc#2042 libcontainer: intelrdt: add missing destroy handler in defer func
  - opencontainers/runc#2047 Move systemd.Manager initialization into a function in that module
  - opencontainers/runc#2057 main: not reopen /dev/stderr
      - closes opencontainers/runc#2056 Runc + podman|cri-o + systemd issue with stderr
      - closes kubernetes/kubernetes#77615 kubelet fails starting CRI-O containers (Ubuntu 18.04 + systemd cgroups driver)
      - closes cri-o/cri-o#2368 Joining worker node not starting flannel or kube-proxy / CRI-O error "open /dev/stderr: no such device or address"
  - opencontainers/runc#2061 libcontainer: fix TestGetContainerState to check configs.NEWCGROUP
  - opencontainers/runc#2065 Fix cgroup hugetlb size prefix for kB
  - opencontainers/runc#2067 libcontainer: change seccomp test for clone syscall
  - opencontainers/runc#2074 Update dependency libseccomp-golang
  - opencontainers/runc#2081 Bump CRIU to 3.12
  - opencontainers/runc#2089 doc: First process in container needs `Init: true`
  - opencontainers/runc#2094 Skip searching /dev/.udev for device nodes
      - closes opencontainers/runc#2093 HostDevices() race with older udevd versions
  - opencontainers/runc#2098 man: fix man-pages
  - opencontainers/runc#2103 cgroups/fs: check nil pointers in cgroup manager
  - opencontainers/runc#2107 Make get devices function public
  - opencontainers/runc#2113 libcontainer: initial support for cgroups v2
  - opencontainers/runc#2116 Avoid the dependency on cgo through go-systemd/util package
      - removes github.com/coreos/pkg as dependency
  - opencontainers/runc#2117 Remove libcontainer detection for systemd features
      - fixes opencontainers/runc#2117 Cache the systemd detection results
  - opencontainers/runc#2119 libcontainer: update masked paths of /proc
      - relates to moby/moby#36368 Add /proc/keys to masked paths
      - relates to moby/moby#38299 Masked /proc/asound
      - relates to moby/moby#37404 Add /proc/acpi to masked paths (CVE-2018-10892)
  - opencontainers/runc#2122 nsenter: minor fixes
  - opencontainers/runc#2123 Bump x/sys and update syscall for initial Risc-V support
  - opencontainers/runc#2125 cgroup: support mount of cgroup2
  - opencontainers/runc#2126 libcontainer/nsenter: Don't import C in non-cgo file
  - opencontainers/runc#2129 Only allow proc mount if it is procfs
      - addresses opencontainers/runc#2129 AppArmor can be bypassed by a malicious image that specifies a volume at /proc (CVE-2019-16884)
