### PR TITLE
[18.09] bump golang 1.12.10 (CVE-2019-16276)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@
 #
 
 ARG CROSS="false"
-ARG GO_VERSION=1.11.13
+ARG GO_VERSION=1.12.10
 ARG DEBIAN_FRONTEND=noninteractive
 
 FROM golang:${GO_VERSION}-stretch AS base

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.11.13
+ARG GO_VERSION=1.12.10
 
 FROM golang:${GO_VERSION}-alpine3.9 AS builder
 

--- a/Dockerfile.simple
+++ b/Dockerfile.simple
@@ -5,7 +5,7 @@
 
 # This represents the bare minimum required to build and test Docker.
 
-ARG GO_VERSION=1.11.13
+ARG GO_VERSION=1.12.10
 
 FROM golang:${GO_VERSION}-stretch
 

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -158,7 +158,7 @@ FROM microsoft/windowsservercore
 # Use PowerShell as the default shell
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ARG GO_VERSION=1.11.13
+ARG GO_VERSION=1.12.10
 
 # Environment variable notes:
 #  - GO_VERSION must be consistent with 'Dockerfile' used by Linux.


### PR DESCRIPTION
Since golang 1.11 is no longer maintained and in view of [recent golang security update](https://groups.google.com/forum/#!msg/golang-announce/cszieYyuL9Q/g4Z7pKaqAgAJ), let's jump straight to 1.12.10.