### PR TITLE
[18.09 backport] API: update docs that /session left experimental in V1.39

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -10223,9 +10223,6 @@ paths:
       description: |
         Start a new interactive session with a server. Session allows server to call back to the client for advanced capabilities.
 
-        > **Note**: This endpoint is *experimental* and only available if the daemon is started with experimental
-        > features enabled. The specifications for this endpoint may still change in a future version of the API.
-
         ### Hijacking
 
         This endpoint hijacks the HTTP connection to HTTP2 transport that allows the client to expose gPRC services on that connection.
@@ -10259,4 +10256,4 @@ paths:
           description: "server error"
           schema:
             $ref: "#/definitions/ErrorResponse"
-      tags: ["Session (experimental)"]
+      tags: ["Session"]

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -26,6 +26,9 @@ keywords: "API, Docker, rcli, REST, documentation"
 * `POST /swarm/init` now accepts a `DefaultAddrPool` property to set global scope default address pool
 * `POST /swarm/init` now accepts a `SubnetSize` property to set global scope networks by giving the
   length of the subnet masks for every such network
+* `POST /session` (added in [V1.31](#v131-api-changes) is no longer experimental.
+  This endpoint can be used to run interactive long-running protocols between the
+  client and the daemon.
 
 ## V1.38 API changes
 


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/40028


The /session endpoint left experimental in API V1.39 / Docker 18.09 through 239047c2d36706f2826b0a9bc115e0a08b1c3d27 and 01c9e7082eba71cbe60ce2e47acb9aad2c83c7ef (https://github.com/moby/moby/pull/37686), but the API reference was not updated accordingly.

This updates the API documentation to match the change.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
```Markdown
* API: update docs that `/session` endpoint left experimental in V1.39 [moby/moby#40028](https://github.com/moby/moby/pull/40028)
```

**- A picture of a cute animal (not mandatory but encouraged)**
