### PR TITLE
[19.03 backport] Temporarily switch docker-py to "master"

### DIFF
--- a/hack/make/test-docker-py
+++ b/hack/make/test-docker-py
@@ -7,7 +7,7 @@ source hack/make/.integration-test-helpers
 # TODO docker 17.06 cli client used in CI fails to build using a sha;
 # unable to prepare context: unable to 'git clone' to temporary context directory: error fetching: error: no such remote ref ead0bb9e08c13dd3d1712759491eee06bf5a5602
 #: exit status 128
-: "${DOCKER_PY_COMMIT:=4.0.2}"
+: "${DOCKER_PY_COMMIT:=master}"
 
 # custom options to pass py.test
 # TODO remove these skip once we update to a docker-py version that has https://github.com/docker/docker-py/pull/2369, https://github.com/docker/docker-py/pull/2380, https://github.com/docker/docker-py/pull/2382


### PR DESCRIPTION
clean cherry-pick of 48353e1 from https://github.com/moby/moby/pull/40030
```
$ git cherry-pick -s -x 48353e16fe4bc06764ceb6bced0fbe832803ede4
[bump_docker_py ec0e20a9eb] Temporarily switch docker-py to "master"
 Author: Sebastiaan van Stijn <github@gone.nl>
 Date: Wed Oct 2 17:54:48 2019 +0200
 1 file changed, 1 insertion(+), 1 deletion(-)
```