### PR TITLE
[19.03] roll-back libnetwork iptables forward policy change [DESKTOP-1934]

### DIFF
--- a/hack/dockerfile/install/proxy.installer
+++ b/hack/dockerfile/install/proxy.installer
@@ -3,7 +3,7 @@
 # LIBNETWORK_COMMIT is used to build the docker-userland-proxy binary. When
 # updating the binary version, consider updating github.com/docker/libnetwork
 # in vendor.conf accordingly
-LIBNETWORK_COMMIT=96bcc0dae898308ed659c5095526788a602f4726
+LIBNETWORK_COMMIT=45c710223c5fbf04dc3028b9a90b51892e36ca7f
 
 install_proxy() {
 	case "$1" in

--- a/vendor.conf
+++ b/vendor.conf
@@ -38,7 +38,7 @@ github.com/gofrs/flock                              7f43ea2e6a643ad441fc12d0ecc0
 # libnetwork
 
 # When updating, also update LIBNETWORK_COMMIT in hack/dockerfile/install/proxy.installer accordingly
-github.com/docker/libnetwork                        96bcc0dae898308ed659c5095526788a602f4726
+github.com/docker/libnetwork                        45c710223c5fbf04dc3028b9a90b51892e36ca7f
 github.com/docker/go-events                         9461782956ad83b30282bf90e31fa6a70c255ba9
 github.com/armon/go-radix                           e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics                         eb0af217e5e9747e41dd5303755356b62d28e3ec

--- a/vendor/github.com/docker/libnetwork/drivers/bridge/setup_ip_forwarding.go
+++ b/vendor/github.com/docker/libnetwork/drivers/bridge/setup_ip_forwarding.go
@@ -34,11 +34,11 @@ func setupIPForwarding(enableIPTables bool) error {
 		if err := configureIPForwarding(true); err != nil {
 			return fmt.Errorf("Enabling IP forwarding failed: %v", err)
 		}
-	}
-
-	// Set the default policy on forward chain to drop only if the
-	// daemon option iptables is not set to false.
-	if enableIPTables {
+		// When enabling ip_forward set the default policy on forward chain to
+		// drop only if the daemon option iptables is not set to false.
+		if !enableIPTables {
+			return nil
+		}
 		if err := iptables.SetDefaultPolicy(iptables.Filter, "FORWARD", iptables.Drop); err != nil {
 			if err := configureIPForwarding(false); err != nil {
 				logrus.Errorf("Disabling IP forwarding failed, %v", err)


### PR DESCRIPTION
this rolls back the libnetwork bump from https://github.com/docker/engine/commit/559be42fc26048f4069de64f84202803a113413a with 1 commit

The patch made in  docker/libnetwork#2450 caused a breaking change in the
networking behaviour, causing Kubernetes installations on Docker Desktop
(and possibly other setups) to fail.

Rolling back this change in the 19.03 branch while we investigate if there
are alternatives.

diff: https://github.com/docker/libnetwork/compare/45c710223c5fbf04dc3028b9a90b51892e36ca7f...96bcc0dae898308ed659c5095526788a602f4726

