### PR TITLE
[19.03 backport] revert controller: Check if IPTables is enabled for arrangeUserFilterRule ENGCORE-1114

### DIFF
--- a/hack/dockerfile/install/proxy.installer
+++ b/hack/dockerfile/install/proxy.installer
@@ -3,7 +3,7 @@
 # LIBNETWORK_COMMIT is used to build the docker-userland-proxy binary. When
 # updating the binary version, consider updating github.com/docker/libnetwork
 # in vendor.conf accordingly
-LIBNETWORK_COMMIT=45c710223c5fbf04dc3028b9a90b51892e36ca7f
+LIBNETWORK_COMMIT=3eb39382bfa6a3c42f83674ab080ae13b0e34e5d # bump_19.03 branch
 
 install_proxy() {
 	case "$1" in

--- a/vendor.conf
+++ b/vendor.conf
@@ -38,7 +38,7 @@ github.com/gofrs/flock                              7f43ea2e6a643ad441fc12d0ecc0
 # libnetwork
 
 # When updating, also update LIBNETWORK_COMMIT in hack/dockerfile/install/proxy.installer accordingly
-github.com/docker/libnetwork                        45c710223c5fbf04dc3028b9a90b51892e36ca7f
+github.com/docker/libnetwork                        3eb39382bfa6a3c42f83674ab080ae13b0e34e5d # bump_19.03 branch
 github.com/docker/go-events                         9461782956ad83b30282bf90e31fa6a70c255ba9
 github.com/armon/go-radix                           e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics                         eb0af217e5e9747e41dd5303755356b62d28e3ec

--- a/vendor/github.com/docker/libnetwork/firewall_linux.go
+++ b/vendor/github.com/docker/libnetwork/firewall_linux.go
@@ -2,7 +2,6 @@ package libnetwork
 
 import (
 	"github.com/docker/libnetwork/iptables"
-	"github.com/docker/libnetwork/netlabel"
 	"github.com/sirupsen/logrus"
 )
 
@@ -10,42 +9,13 @@ const userChain = "DOCKER-USER"
 
 func (c *controller) arrangeUserFilterRule() {
 	c.Lock()
-
-	if c.hasIPTablesEnabled() {
-		arrangeUserFilterRule()
-	}
-
+	arrangeUserFilterRule()
 	c.Unlock()
-
 	iptables.OnReloaded(func() {
 		c.Lock()
-
-		if c.hasIPTablesEnabled() {
-			arrangeUserFilterRule()
-		}
-
+		arrangeUserFilterRule()
 		c.Unlock()
 	})
-}
-
-func (c *controller) hasIPTablesEnabled() bool {
-	// Locking c should be handled in the calling method.
-	if c.cfg == nil || c.cfg.Daemon.DriverCfg[netlabel.GenericData] == nil {
-		return false
-	}
-
-	genericData, ok := c.cfg.Daemon.DriverCfg[netlabel.GenericData]
-	if !ok {
-		return false
-	}
-
-	optMap := genericData.(map[string]interface{})
-	enabled, ok := optMap["EnableIPTables"].(bool)
-	if !ok {
-		return false
-	}
-
-	return enabled
 }
 
 // This chain allow users to configure firewall policies in a way that persists


### PR DESCRIPTION
This change caused a regression, causing the DOCKER-USER chain
to not be created, despite iptables being enabled on the daemon.

- updates lib network to the latest bump_19.03 branch
- brings in https://github.com/docker/libnetwork/pull/2470 [19.03] revert controller: Check if IPTables is enabled for arrangeUserFilterRule ENGCORE-1114
- reverts https://github.com/docker/libnetwork/pull/2339 controller: Check if IPTables is enabled for arrangeUserFilterRule
- fixes [ENGCORE-1114]
- fixes https://github.com/docker/for-linux/issues/810 DOCKER-USER iptables chain missing in 19.03.3

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**



[ENGCORE-1114]: https://docker.atlassian.net/browse/ENGCORE-1114