### PR TITLE
[19.03 backport] Propagate GetContainer error from event processor

### DIFF
--- a/daemon/monitor.go
+++ b/daemon/monitor.go
@@ -2,8 +2,6 @@ package daemon // import "github.com/docker/docker/daemon"
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"runtime"
 	"strconv"
 	"time"
@@ -12,6 +10,7 @@ import (
 	"github.com/docker/docker/container"
 	libcontainerdtypes "github.com/docker/docker/libcontainerd/types"
 	"github.com/docker/docker/restartmanager"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -29,8 +28,8 @@ func (daemon *Daemon) setStateCounter(c *container.Container) {
 // ProcessEvent is called by libcontainerd whenever an event occurs
 func (daemon *Daemon) ProcessEvent(id string, e libcontainerdtypes.EventType, ei libcontainerdtypes.EventInfo) error {
 	c, err := daemon.GetContainer(id)
-	if c == nil || err != nil {
-		return fmt.Errorf("no such container: %s", id)
+	if err != nil {
+		return errors.Wrapf(err, "could not find container %s", id)
 	}
 
 	switch e {


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/39497

Before this change we just accept that any error is "not found" and it
could be something else, but even if it it is just a "not found" kind of
error this should be dealt with from the container store and not the
event processor.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
