### PR TITLE
[18.09 backport] daemon/config: fix filter type in BuildKit GC config

### DIFF
--- a/api/types/filters/parse.go
+++ b/api/types/filters/parse.go
@@ -323,6 +323,22 @@ func (args Args) WalkValues(field string, op func(value string) error) error {
 	return nil
 }
 
+// Clone returns a copy of args.
+func (args Args) Clone() (newArgs Args) {
+	newArgs.fields = make(map[string]map[string]bool, len(args.fields))
+	for k, m := range args.fields {
+		var mm map[string]bool
+		if m != nil {
+			mm = make(map[string]bool, len(m))
+			for kk, v := range m {
+				mm[kk] = v
+			}
+		}
+		newArgs.fields[k] = mm
+	}
+	return newArgs
+}
+
 func deprecatedArgs(d map[string][]string) map[string]map[string]bool {
 	m := map[string]map[string]bool{}
 	for k, v := range d {

--- a/api/types/filters/parse.go
+++ b/api/types/filters/parse.go
@@ -5,7 +5,6 @@ package filters // import "github.com/docker/docker/api/types/filters"
 
 import (
 	"encoding/json"
-	"errors"
 	"regexp"
 	"strings"
 
@@ -35,41 +34,6 @@ func NewArgs(initialArgs ...KeyValuePair) Args {
 		args.Add(arg.Key, arg.Value)
 	}
 	return args
-}
-
-// ParseFlag parses a key=value string and adds it to an Args.
-//
-// Deprecated: Use Args.Add()
-func ParseFlag(arg string, prev Args) (Args, error) {
-	filters := prev
-	if len(arg) == 0 {
-		return filters, nil
-	}
-
-	if !strings.Contains(arg, "=") {
-		return filters, ErrBadFormat
-	}
-
-	f := strings.SplitN(arg, "=", 2)
-
-	name := strings.ToLower(strings.TrimSpace(f[0]))
-	value := strings.TrimSpace(f[1])
-
-	filters.Add(name, value)
-
-	return filters, nil
-}
-
-// ErrBadFormat is an error returned when a filter is not in the form key=value
-//
-// Deprecated: this error will be removed in a future version
-var ErrBadFormat = errors.New("bad format of filter (expected name=value)")
-
-// ToParam encodes the Args as args JSON encoded string
-//
-// Deprecated: use ToJSON
-func ToParam(a Args) (string, error) {
-	return ToJSON(a)
 }
 
 // MarshalJSON returns a JSON byte representation of the Args
@@ -105,13 +69,6 @@ func ToParamWithVersion(version string, a Args) (string, error) {
 	}
 
 	return ToJSON(a)
-}
-
-// FromParam decodes a JSON encoded string into Args
-//
-// Deprecated: use FromJSON
-func FromParam(p string) (Args, error) {
-	return FromJSON(p)
 }
 
 // FromJSON decodes a JSON encoded string into Args
@@ -273,14 +230,6 @@ func (args Args) FuzzyMatch(key, source string) bool {
 		}
 	}
 	return false
-}
-
-// Include returns true if the key exists in the mapping
-//
-// Deprecated: use Contains
-func (args Args) Include(field string) bool {
-	_, ok := args.fields[field]
-	return ok
 }
 
 // Contains returns true if the key exists in the mapping

--- a/api/types/filters/parse.go
+++ b/api/types/filters/parse.go
@@ -36,6 +36,14 @@ func NewArgs(initialArgs ...KeyValuePair) Args {
 	return args
 }
 
+func (args Args) Keys() []string {
+	keys := make([]string, 0, len(args.fields))
+	for k := range args.fields {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
 // MarshalJSON returns a JSON byte representation of the Args
 func (args Args) MarshalJSON() ([]byte, error) {
 	if len(args.fields) == 0 {

--- a/api/types/filters/parse.go
+++ b/api/types/filters/parse.go
@@ -36,6 +36,7 @@ func NewArgs(initialArgs ...KeyValuePair) Args {
 	return args
 }
 
+// Keys returns all the keys in list of Args
 func (args Args) Keys() []string {
 	keys := make([]string, 0, len(args.fields))
 	for k := range args.fields {

--- a/api/types/filters/parse_test.go
+++ b/api/types/filters/parse_test.go
@@ -8,40 +8,6 @@ import (
 	is "gotest.tools/assert/cmp"
 )
 
-func TestParseArgs(t *testing.T) {
-	// equivalent of `docker ps -f 'created=today' -f 'image.name=ubuntu*' -f 'image.name=*untu'`
-	flagArgs := []string{
-		"created=today",
-		"image.name=ubuntu*",
-		"image.name=*untu",
-	}
-	var (
-		args = NewArgs()
-		err  error
-	)
-
-	for i := range flagArgs {
-		args, err = ParseFlag(flagArgs[i], args)
-		assert.NilError(t, err)
-	}
-	assert.Check(t, is.Len(args.Get("created"), 1))
-	assert.Check(t, is.Len(args.Get("image.name"), 2))
-}
-
-func TestParseArgsEdgeCase(t *testing.T) {
-	var args Args
-	args, err := ParseFlag("", args)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if args.Len() != 0 {
-		t.Fatalf("Expected an empty Args (map), got %v", args)
-	}
-	if args, err = ParseFlag("anything", args); err == nil || err != ErrBadFormat {
-		t.Fatalf("Expected ErrBadFormat, got %v", err)
-	}
-}
-
 func TestToJSON(t *testing.T) {
 	fields := map[string]map[string]bool{
 		"created":    {"today": true},
@@ -344,17 +310,6 @@ func TestContains(t *testing.T) {
 	f.Add("status", "running")
 	if !f.Contains("status") {
 		t.Fatal("Expected to contain a status key, got false")
-	}
-}
-
-func TestInclude(t *testing.T) {
-	f := NewArgs()
-	if f.Include("status") {
-		t.Fatal("Expected to not include a status key, got true")
-	}
-	f.Add("status", "running")
-	if !f.Include("status") {
-		t.Fatal("Expected to include a status key, got false")
 	}
 }
 

--- a/api/types/filters/parse_test.go
+++ b/api/types/filters/parse_test.go
@@ -421,3 +421,11 @@ func TestFuzzyMatch(t *testing.T) {
 		}
 	}
 }
+
+func TestClone(t *testing.T) {
+	f := NewArgs()
+	f.Add("foo", "bar")
+	f2 := f.Clone()
+	f2.Add("baz", "qux")
+	assert.Check(t, is.Len(f.Get("baz"), 0))
+}

--- a/builder/builder-next/builder.go
+++ b/builder/builder-next/builder.go
@@ -560,7 +560,7 @@ func toBuildkitPruneInfo(opts types.BuildCachePruneOptions) (client.PruneInfo, e
 
 	bkFilter := make([]string, 0, opts.Filters.Len())
 	for cacheField := range cacheFields {
-		if opts.Filters.Include(cacheField) {
+		if opts.Filters.Contains(cacheField) {
 			values := opts.Filters.Get(cacheField)
 			switch len(values) {
 			case 0:

--- a/builder/builder-next/controller.go
+++ b/builder/builder-next/controller.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/containerd/containerd/content/local"
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/builder/builder-next/adapters/containerimage"
 	"github.com/docker/docker/builder/builder-next/adapters/snapshot"
 	containerimageexp "github.com/docker/docker/builder/builder-next/exporter"
@@ -206,7 +207,7 @@ func getGCPolicy(conf config.BuilderConfig, root string) ([]client.PruneInfo, er
 				gcPolicy[i], err = toBuildkitPruneInfo(types.BuildCachePruneOptions{
 					All:         p.All,
 					KeepStorage: b,
-					Filters:     p.Filter,
+					Filters:     filters.Args(p.Filter),
 				})
 				if err != nil {
 					return nil, err

--- a/daemon/config/builder.go
+++ b/daemon/config/builder.go
@@ -16,8 +16,10 @@ type BuilderGCRule struct {
 	KeepStorage string          `json:",omitempty"`
 }
 
+// BuilderGCFilter contains garbage-collection filter rules for a BuildKit builder
 type BuilderGCFilter filters.Args
 
+// MarshalJSON returns a JSON byte representation of the BuilderGCFilter
 func (x *BuilderGCFilter) MarshalJSON() ([]byte, error) {
 	f := filters.Args(*x)
 	keys := f.Keys()
@@ -32,6 +34,7 @@ func (x *BuilderGCFilter) MarshalJSON() ([]byte, error) {
 	return json.Marshal(arr)
 }
 
+// UnmarshalJSON fills the BuilderGCFilter values structure from JSON input
 func (x *BuilderGCFilter) UnmarshalJSON(data []byte) error {
 	var arr []string
 	f := filters.NewArgs()

--- a/daemon/config/builder.go
+++ b/daemon/config/builder.go
@@ -1,12 +1,38 @@
 package config
 
-import "github.com/docker/docker/api/types/filters"
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/docker/docker/api/types/filters"
+)
 
 // BuilderGCRule represents a GC rule for buildkit cache
 type BuilderGCRule struct {
-	All         bool         `json:",omitempty"`
-	Filter      filters.Args `json:",omitempty"`
-	KeepStorage string       `json:",omitempty"`
+	All         bool            `json:",omitempty"`
+	Filter      BuilderGCFilter `json:",omitempty"`
+	KeepStorage string          `json:",omitempty"`
+}
+
+type BuilderGCFilter filters.Args
+
+func (x *BuilderGCFilter) UnmarshalJSON(data []byte) error {
+	var arr []string
+	f := filters.NewArgs()
+	if err := json.Unmarshal(data, &arr); err != nil {
+		// backwards compat for deprecated buggy form
+		err := json.Unmarshal(data, &f)
+		*x = BuilderGCFilter(f)
+		return err
+	}
+	for _, s := range arr {
+		fields := strings.SplitN(s, "=", 2)
+		name := strings.ToLower(strings.TrimSpace(fields[0]))
+		value := strings.TrimSpace(fields[1])
+		f.Add(name, value)
+	}
+	*x = BuilderGCFilter(f)
+	return nil
 }
 
 // BuilderGCConfig contains GC config for a buildkit builder

--- a/daemon/config/builder.go
+++ b/daemon/config/builder.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"encoding/json"
+	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/docker/docker/api/types/filters"
@@ -15,6 +17,20 @@ type BuilderGCRule struct {
 }
 
 type BuilderGCFilter filters.Args
+
+func (x *BuilderGCFilter) MarshalJSON() ([]byte, error) {
+	f := filters.Args(*x)
+	keys := f.Keys()
+	sort.Strings(keys)
+	arr := make([]string, 0, len(keys))
+	for _, k := range keys {
+		values := f.Get(k)
+		for _, v := range values {
+			arr = append(arr, fmt.Sprintf("%s=%s", k, v))
+		}
+	}
+	return json.Marshal(arr)
+}
 
 func (x *BuilderGCFilter) UnmarshalJSON(data []byte) error {
 	var arr []string

--- a/daemon/config/builder_test.go
+++ b/daemon/config/builder_test.go
@@ -1,0 +1,44 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/docker/docker/api/types/filters"
+	"github.com/google/go-cmp/cmp"
+	"gotest.tools/assert"
+	"gotest.tools/fs"
+)
+
+func TestBuilderGC(t *testing.T) {
+	tempFile := fs.NewFile(t, "config", fs.WithContent(`{
+  "builder": {
+    "gc": {
+      "enabled": true,
+      "policy": [
+        {"keepStorage": "10GB", "filter": ["unused-for=2200h"]},
+        {"keepStorage": "50GB", "filter": {"unused-for": {"3300h": true}}},
+        {"keepStorage": "100GB", "all": true}
+      ]
+    }
+  }
+}`))
+	defer tempFile.Remove()
+	configFile := tempFile.Path()
+
+	cfg, err := MergeDaemonConfigurations(&Config{}, nil, configFile)
+	assert.NilError(t, err)
+	assert.Assert(t, cfg.Builder.GC.Enabled)
+	f1 := filters.NewArgs()
+	f1.Add("unused-for", "2200h")
+	f2 := filters.NewArgs()
+	f2.Add("unused-for", "3300h")
+	expectedPolicy := []BuilderGCRule{
+		{KeepStorage: "10GB", Filter: BuilderGCFilter(f1)},
+		{KeepStorage: "50GB", Filter: BuilderGCFilter(f2)}, /* parsed from deprecated form */
+		{KeepStorage: "100GB", All: true},
+	}
+	assert.DeepEqual(t, cfg.Builder.GC.Policy, expectedPolicy, cmp.AllowUnexported(BuilderGCFilter{}))
+	// double check to please the skeptics
+	assert.Assert(t, filters.Args(cfg.Builder.GC.Policy[0].Filter).UniqueExactMatch("unused-for", "2200h"))
+	assert.Assert(t, filters.Args(cfg.Builder.GC.Policy[1].Filter).UniqueExactMatch("unused-for", "3300h"))
+}


### PR DESCRIPTION
backport of 

- https://github.com/moby/moby/pull/38239 filters: add Clone() method
    - used in testing
- https://github.com/moby/moby/pull/39029 Remove deprecated filter functions
    - to get a clean cherry-pick; only removes some dead code
- https://github.com/moby/moby/pull/39979 daemon/config: fix filter type in BuildKit GC config
    - fixes https://github.com/moby/moby/issues/39601 "Example Buildkit GC configuration results in daemon error"
- https://github.com/moby/moby/pull/40118 Add GoDoc to fix linting validation

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
