### PR TITLE
[19.03 backport] Jenkinsfile: set repo and branch for DCO check as well

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,7 +47,9 @@ pipeline {
                 sh '''
                 docker run --rm \
                   -v "$WORKSPACE:/workspace" \
-                  alpine sh -c 'apk add --no-cache -q git bash && cd /workspace && hack/validate/dco'
+                  -e VALIDATE_REPO=${GIT_URL} \
+                  -e VALIDATE_BRANCH=${CHANGE_TARGET} \
+                  alpine sh -c 'apk add --no-cache -q bash git openssh-client && cd /workspace && hack/validate/dco'
                 '''
             }
         }


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/40119

Commit 7019b60d0d6f3d69e6ccf481ca0a912905a9c1d (https://github.com/moby/moby/pull/40035) added these
env-vars to other stages, but forgot to update the DCO stage,
which also does a diff to validate commits that are in a PR.


this should fix the issue we're seeing in https://github.com/docker/engine/pull/408#issuecomment-544376931
