### PR TITLE
[19.03 backport][Carry 39595] Tailor CI for ARM, skip legacy integration test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     parameters {
         booleanParam(name: 'unit_validate', defaultValue: true, description: 'amd64 (x86_64) unit tests and vendor check')
         booleanParam(name: 'amd64', defaultValue: true, description: 'amd64 (x86_64) Build/Test')
-        booleanParam(name: 'aarch64', defaultValue: true, description: 'ARM (aarch64) Build/Test')
+        booleanParam(name: 'arm64', defaultValue: true, description: 'ARM (arm64) Build/Test')
         booleanParam(name: 's390x', defaultValue: true, description: 'IBM Z (s390x) Build/Test')
         booleanParam(name: 'ppc64le', defaultValue: true, description: 'PowerPC (ppc64le) Build/Test')
         booleanParam(name: 'windowsRS1', defaultValue: false, description: 'Windows 2016 (RS1) Build/Test')
@@ -751,10 +751,10 @@ pipeline {
                         }
                     }
                 }
-                stage('aarch64') {
+                stage('arm64') {
                     when {
                         beforeAgent true
-                        expression { params.aarch64 }
+                        expression { params.arm64 }
                     }
                     agent { label 'aarch64 && packet' }
                     environment {
@@ -823,10 +823,10 @@ pipeline {
 
                             sh '''
                             echo "Creating bundles.tar.gz"
-                            find bundles -name '*.log' | xargs tar -czf aarch64-bundles.tar.gz
+                            find bundles -name '*.log' | xargs tar -czf arm64-bundles.tar.gz
                             '''
 
-                            archiveArtifacts artifacts: 'aarch64-bundles.tar.gz'
+                            archiveArtifacts artifacts: 'arm64-bundles.tar.gz'
                         }
                         cleanup {
                             sh 'make clean'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -751,6 +751,45 @@ pipeline {
                         }
                     }
                 }
+                stage('aarch64') {
+                    when {
+                        beforeAgent true
+                        expression { params.aarch64 }
+                    }
+                    agent { label 'aarch64 && packet' }
+                    steps {
+                        sh '''
+                        GITCOMMIT=$(git rev-parse --short HEAD)
+
+                        docker build --rm --force-rm --build-arg APT_MIRROR=cdn-fastly.deb.debian.org -t docker-aarch64:$GITCOMMIT -f Dockerfile .
+
+                        docker run --rm -t --privileged \
+                          -v "$WORKSPACE/bundles:/go/src/github.com/docker/docker/bundles" \
+                          --name docker-pr-aarch64$BUILD_NUMBER \
+                          -e DOCKER_GRAPHDRIVER=vfs \
+                          -e DOCKER_EXECDRIVER=native \
+                          -e DOCKER_GITCOMMIT=${GITCOMMIT} \
+                          docker-aarch64:$GITCOMMIT \
+                          hack/ci/arm
+                        '''
+                    }
+                    post {
+                        always {
+                            sh '''
+                            echo "Ensuring container killed."
+                            docker rm -vf docker-pr-aarch64$BUILD_NUMBER || true
+
+                            echo "Chowning /workspace to jenkins user"
+                            docker run --rm -v "$WORKSPACE:/workspace" aarch64/busybox chown -R "$(id -u):$(id -g)" /workspace
+                            '''
+                            sh '''
+                            echo "Creating bundles.tar.gz"
+                            find bundles -name '*.log' | xargs tar -czf bundles.tar.gz
+                            '''
+                            archiveArtifacts artifacts: 'bundles.tar.gz'
+                        }
+                    }
+                }
                 stage('win-RS1') {
                     when {
                         beforeAgent true
@@ -875,45 +914,6 @@ pipeline {
                             deleteDir()
                         }
                     }
-                }
-            }
-        }
-        stage('aarch64') {
-            when {
-                beforeAgent true
-                expression { params.aarch64 }
-            }
-            agent { label 'aarch64 && packet' }
-            steps {
-                sh '''
-                GITCOMMIT=$(git rev-parse --short HEAD)
-
-                docker build --rm --force-rm --build-arg APT_MIRROR=cdn-fastly.deb.debian.org -t docker-aarch64:$GITCOMMIT -f Dockerfile .
-
-                docker run --rm -t --privileged \
-                  -v "$WORKSPACE/bundles:/go/src/github.com/docker/docker/bundles" \
-                  --name docker-pr-aarch64$BUILD_NUMBER \
-                  -e DOCKER_GRAPHDRIVER=vfs \
-                  -e DOCKER_EXECDRIVER=native \
-                  -e DOCKER_GITCOMMIT=${GITCOMMIT} \
-                  docker-aarch64:$GITCOMMIT \
-                  hack/ci/arm
-                '''
-            }
-            post {
-                always {
-                    sh '''
-                    echo "Ensuring container killed."
-                    docker rm -vf docker-pr-aarch64$BUILD_NUMBER || true
-
-                    echo "Chowning /workspace to jenkins user"
-                    docker run --rm -v "$WORKSPACE:/workspace" aarch64/busybox chown -R "$(id -u):$(id -g)" /workspace
-                    '''
-                    sh '''
-                    echo "Creating bundles.tar.gz"
-                    find bundles -name '*.log' | xargs tar -czf bundles.tar.gz
-                    '''
-                    archiveArtifacts artifacts: 'bundles.tar.gz'
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -761,20 +761,53 @@ pipeline {
                         TEST_SKIP_INTEGRATION_CLI = '1'
                     }
 
-                    steps {
-                        sh '''
-                        docker run --rm -t --privileged \
-                          -v "$WORKSPACE/bundles:/go/src/github.com/docker/docker/bundles" \
-                          --name docker-pr$BUILD_NUMBER \
-                          -e DOCKER_GITCOMMIT=${GIT_COMMIT} \
-                          -e DOCKER_GRAPHDRIVER \
-                          -e TEST_SKIP_INTEGRATION_CLI \
-                          docker:${GIT_COMMIT} \
-                          hack/make.sh \
-                            binary-daemon \
-                            dynbinary \
-                            test-integration
-                        '''
+                    stages {
+                        stage("Print info") {
+                            steps {
+                                sh 'docker version'
+                                sh 'docker info'
+                                sh '''
+                                echo "check-config.sh version: ${CHECK_CONFIG_COMMIT}"
+                                curl -fsSL -o ${WORKSPACE}/check-config.sh "https://raw.githubusercontent.com/moby/moby/${CHECK_CONFIG_COMMIT}/contrib/check-config.sh" \
+                                && bash ${WORKSPACE}/check-config.sh || true
+                                '''
+                            }
+                        }
+                        stage("Build dev image") {
+                            steps {
+                                sh 'docker build --force-rm --build-arg APT_MIRROR -t docker:${GIT_COMMIT} -f Dockerfile .'
+                            }
+                        }
+                        stage("Unit tests") {
+                            steps {
+                                sh '''
+                                docker run --rm -t --privileged \
+                                  -v "$WORKSPACE/bundles:/go/src/github.com/docker/docker/bundles" \
+                                  --name docker-pr$BUILD_NUMBER \
+                                  -e DOCKER_GITCOMMIT=${GIT_COMMIT} \
+                                  -e DOCKER_GRAPHDRIVER \
+                                  docker:${GIT_COMMIT} \
+                                  hack/test/unit
+                                '''
+                            }
+                        }
+                        stage("Integration tests") {
+                            steps {
+                                sh '''
+                                docker run --rm -t --privileged \
+                                  -v "$WORKSPACE/bundles:/go/src/github.com/docker/docker/bundles" \
+                                  --name docker-pr$BUILD_NUMBER \
+                                  -e DOCKER_GITCOMMIT=${GIT_COMMIT} \
+                                  -e DOCKER_GRAPHDRIVER \
+                                  -e TEST_SKIP_INTEGRATION_CLI \
+                                  docker:${GIT_COMMIT} \
+                                  hack/make.sh \
+                                    binary-daemon \
+                                    dynbinary \
+                                    test-integration
+                                '''
+                            }
+                        }
                     }
                     post {
                         always {
@@ -794,6 +827,10 @@ pipeline {
                             '''
 
                             archiveArtifacts artifacts: 'aarch64-bundles.tar.gz'
+                        }
+                        cleanup {
+                            sh 'make clean'
+                            deleteDir()
                         }
                     }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -756,7 +756,7 @@ pipeline {
                         beforeAgent true
                         expression { params.arm64 }
                     }
-                    agent { label 'aarch64' }
+                    agent { label 'arm64 && linux' }
                     environment {
                         TEST_SKIP_INTEGRATION_CLI = '1'
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -775,7 +775,7 @@ pipeline {
                         }
                         stage("Build dev image") {
                             steps {
-                                sh 'docker build --force-rm --build-arg APT_MIRROR -t docker:${GIT_COMMIT} -f Dockerfile .'
+                                sh 'docker build --force-rm --build-arg APT_MIRROR -t docker:${GIT_COMMIT} .'
                             }
                         }
                         stage("Unit tests") {
@@ -784,31 +784,50 @@ pipeline {
                                 docker run --rm -t --privileged \
                                   -v "$WORKSPACE/bundles:/go/src/github.com/docker/docker/bundles" \
                                   --name docker-pr$BUILD_NUMBER \
+                                  -e DOCKER_EXPERIMENTAL \
                                   -e DOCKER_GITCOMMIT=${GIT_COMMIT} \
                                   -e DOCKER_GRAPHDRIVER \
+                                  -e VALIDATE_REPO=${GIT_URL} \
+                                  -e VALIDATE_BRANCH=${CHANGE_TARGET} \
                                   docker:${GIT_COMMIT} \
                                   hack/test/unit
                                 '''
                             }
+                            post {
+                                always {
+                                    junit testResults: 'bundles/junit-report.xml', allowEmptyResults: true
+                                }
+                            }
                         }
                         stage("Integration tests") {
+                            environment { TEST_SKIP_INTEGRATION_CLI = '1' }
                             steps {
                                 sh '''
                                 docker run --rm -t --privileged \
                                   -v "$WORKSPACE/bundles:/go/src/github.com/docker/docker/bundles" \
                                   --name docker-pr$BUILD_NUMBER \
+                                  -e DOCKER_EXPERIMENTAL \
                                   -e DOCKER_GITCOMMIT=${GIT_COMMIT} \
                                   -e DOCKER_GRAPHDRIVER \
+                                  -e TESTDEBUG \
                                   -e TEST_SKIP_INTEGRATION_CLI \
+                                  -e TIMEOUT \
+                                  -e VALIDATE_REPO=${GIT_URL} \
+                                  -e VALIDATE_BRANCH=${CHANGE_TARGET} \
                                   docker:${GIT_COMMIT} \
                                   hack/make.sh \
-                                    binary-daemon \
                                     dynbinary \
                                     test-integration
                                 '''
                             }
+                            post {
+                                always {
+                                    junit testResults: 'bundles/**/*-report.xml', allowEmptyResults: true
+                                }
+                            }
                         }
                     }
+
                     post {
                         always {
                             sh '''
@@ -821,12 +840,16 @@ pipeline {
                             docker run --rm -v "$WORKSPACE:/workspace" busybox chown -R "$(id -u):$(id -g)" /workspace
                             '''
 
-                            sh '''
-                            echo "Creating bundles.tar.gz"
-                            find bundles -name '*.log' | xargs tar -czf arm64-bundles.tar.gz
-                            '''
+                            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE', message: 'Failed to create bundles.tar.gz') {
+                                sh '''
+                                bundleName=arm64-integration
+                                echo "Creating ${bundleName}-bundles.tar.gz"
+                                # exclude overlay2 directories
+                                find bundles -path '*/root/*overlay2' -prune -o -type f \\( -name '*-report.json' -o -name '*.log' -o -name '*.prof' -o -name '*-report.xml' \\) -print | xargs tar -czf ${bundleName}-bundles.tar.gz
+                                '''
 
-                            archiveArtifacts artifacts: 'arm64-bundles.tar.gz'
+                                archiveArtifacts artifacts: '*-bundles.tar.gz', allowEmptyArchive: true
+                            }
                         }
                         cleanup {
                             sh 'make clean'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -757,36 +757,43 @@ pipeline {
                         expression { params.aarch64 }
                     }
                     agent { label 'aarch64 && packet' }
+                    environment {
+                        TEST_SKIP_INTEGRATION_CLI = '1'
+                    }
+
                     steps {
                         sh '''
-                        GITCOMMIT=$(git rev-parse --short HEAD)
-
-                        docker build --rm --force-rm --build-arg APT_MIRROR=cdn-fastly.deb.debian.org -t docker-aarch64:$GITCOMMIT -f Dockerfile .
-
                         docker run --rm -t --privileged \
                           -v "$WORKSPACE/bundles:/go/src/github.com/docker/docker/bundles" \
-                          --name docker-pr-aarch64$BUILD_NUMBER \
-                          -e DOCKER_GRAPHDRIVER=vfs \
-                          -e DOCKER_EXECDRIVER=native \
-                          -e DOCKER_GITCOMMIT=${GITCOMMIT} \
-                          docker-aarch64:$GITCOMMIT \
-                          hack/ci/arm
+                          --name docker-pr$BUILD_NUMBER \
+                          -e DOCKER_GITCOMMIT=${GIT_COMMIT} \
+                          -e DOCKER_GRAPHDRIVER \
+                          -e TEST_SKIP_INTEGRATION_CLI \
+                          docker:${GIT_COMMIT} \
+                          hack/make.sh \
+                            binary-daemon \
+                            dynbinary \
+                            test-integration
                         '''
                     }
                     post {
                         always {
                             sh '''
                             echo "Ensuring container killed."
-                            docker rm -vf docker-pr-aarch64$BUILD_NUMBER || true
-
-                            echo "Chowning /workspace to jenkins user"
-                            docker run --rm -v "$WORKSPACE:/workspace" aarch64/busybox chown -R "$(id -u):$(id -g)" /workspace
+                            docker rm -vf docker-pr$BUILD_NUMBER || true
                             '''
+
+                            sh '''
+                            echo "Chowning /workspace to jenkins user"
+                            docker run --rm -v "$WORKSPACE:/workspace" busybox chown -R "$(id -u):$(id -g)" /workspace
+                            '''
+
                             sh '''
                             echo "Creating bundles.tar.gz"
-                            find bundles -name '*.log' | xargs tar -czf bundles.tar.gz
+                            find bundles -name '*.log' | xargs tar -czf aarch64-bundles.tar.gz
                             '''
-                            archiveArtifacts artifacts: 'bundles.tar.gz'
+
+                            archiveArtifacts artifacts: 'aarch64-bundles.tar.gz'
                         }
                     }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,6 +10,7 @@ pipeline {
     parameters {
         booleanParam(name: 'unit_validate', defaultValue: true, description: 'amd64 (x86_64) unit tests and vendor check')
         booleanParam(name: 'amd64', defaultValue: true, description: 'amd64 (x86_64) Build/Test')
+        booleanParam(name: 'aarch64', defaultValue: true, description: 'ARM (aarch64) Build/Test')
         booleanParam(name: 's390x', defaultValue: true, description: 'IBM Z (s390x) Build/Test')
         booleanParam(name: 'ppc64le', defaultValue: true, description: 'PowerPC (ppc64le) Build/Test')
         booleanParam(name: 'windowsRS1', defaultValue: false, description: 'Windows 2016 (RS1) Build/Test')
@@ -874,6 +875,45 @@ pipeline {
                             deleteDir()
                         }
                     }
+                }
+            }
+        }
+        stage('aarch64') {
+            when {
+                beforeAgent true
+                expression { params.aarch64 }
+            }
+            agent { label 'aarch64 && packet' }
+            steps {
+                sh '''
+                GITCOMMIT=$(git rev-parse --short HEAD)
+
+                docker build --rm --force-rm --build-arg APT_MIRROR=cdn-fastly.deb.debian.org -t docker-aarch64:$GITCOMMIT -f Dockerfile .
+
+                docker run --rm -t --privileged \
+                  -v "$WORKSPACE/bundles:/go/src/github.com/docker/docker/bundles" \
+                  --name docker-pr-aarch64$BUILD_NUMBER \
+                  -e DOCKER_GRAPHDRIVER=vfs \
+                  -e DOCKER_EXECDRIVER=native \
+                  -e DOCKER_GITCOMMIT=${GITCOMMIT} \
+                  docker-aarch64:$GITCOMMIT \
+                  hack/ci/arm
+                '''
+            }
+            post {
+                always {
+                    sh '''
+                    echo "Ensuring container killed."
+                    docker rm -vf docker-pr-aarch64$BUILD_NUMBER || true
+
+                    echo "Chowning /workspace to jenkins user"
+                    docker run --rm -v "$WORKSPACE:/workspace" aarch64/busybox chown -R "$(id -u):$(id -g)" /workspace
+                    '''
+                    sh '''
+                    echo "Creating bundles.tar.gz"
+                    find bundles -name '*.log' | xargs tar -czf bundles.tar.gz
+                    '''
+                    archiveArtifacts artifacts: 'bundles.tar.gz'
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -756,7 +756,7 @@ pipeline {
                         beforeAgent true
                         expression { params.arm64 }
                     }
-                    agent { label 'aarch64 && packet' }
+                    agent { label 'aarch64' }
                     environment {
                         TEST_SKIP_INTEGRATION_CLI = '1'
                     }

--- a/hack/ci/arm
+++ b/hack/ci/arm
@@ -4,7 +4,7 @@ set -eu -o pipefail
 
 hack/test/unit
 
-hack/make.sh \
+TEST_SKIP_INTEGRATION_CLI=1 hack/make.sh \
 	binary-daemon \
 	dynbinary \
 	test-integration


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/39678

carry of https://github.com/moby/moby/pull/39595 Tailor CI for ARM, skip legacy integration test
closes https://github.com/moby/moby/pull/39595 Tailor CI for ARM, skip legacy integration test
fixes https://github.com/moby/moby/issues/39479 Jenkins CI for arm64



<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
This PR is trying to make a minimal test set (without legacy integration test cases) for ARM. 
Introduce a new environment variable SKIP_LEGACY_INTEGRATION_TEST to control whether legacy integration test cases are ignored or not. 

**- How I did it**

- Introduce a new environment variable SKIP_LEGACY_INTEGRATION_TEST, default value is "no". 
- If it's set to "yes" or anything rather than "no", legacy integration suites will be skipped.
- In arm CI, SKIP_LEGACY_INTEGRATION_TEST is set to "yes".
- CI for other architecture's are not impacted.

**- How to verify it**
Run "make test-integration" on an ARM machine.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
See the discussion in issue: https://github.com/moby/moby/issues/39479
Backgroud: CI on arm (32 and 64 bit) architecture took too long time to finish. So the CI for it was stopped. Now I am trying to bring it back, and try to set a minimal set in it to save time.

**- A picture of a cute animal (not mandatory but encouraged)**
<img src="https://www.telegraph.co.uk/content/dam/news/2016/07/23/103872971_Mandatory_Credit_Photo_by_Huw_Evans-REX-Shutterstock_5780863o__A_squirrel_invades_the_pitc_trans_NvBQzQNjv4BqnpV-GRdD2fQt8qdeuHLgxdBbmO-kKPcMjZpO6V3FYuw.jpg?imwidth=1400" >
