### PR TITLE
[18.09 backport] Add TC to check dynamic subnet for ingress network

### DIFF
--- a/integration/network/service_test.go
+++ b/integration/network/service_test.go
@@ -363,6 +363,12 @@ func TestServiceWithDefaultAddressPoolInit(t *testing.T) {
 	assert.NilError(t, err)
 	t.Logf("%s: NetworkInspect: %+v", t.Name(), out)
 	assert.Assert(t, len(out.IPAM.Config) > 0)
+	assert.Equal(t, out.IPAM.Config[0].Subnet, "20.20.1.0/24")
+
+	// Also inspect ingress network and make sure its in the same subnet
+	out, err = cli.NetworkInspect(ctx, "ingress", types.NetworkInspectOptions{Verbose: true})
+	assert.NilError(t, err)
+	assert.Assert(t, len(out.IPAM.Config) > 0)
 	assert.Equal(t, out.IPAM.Config[0].Subnet, "20.20.0.0/24")
 
 	err = cli.ServiceRemove(context.Background(), serviceID)


### PR DESCRIPTION
backport of the test from https://github.com/moby/moby/pull/39966, because the related swarmkit changes were included in https://github.com/docker/engine/pull/346