### PR TITLE
[19.03] vendor: update buildkit to ff93519ee

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -26,7 +26,7 @@ github.com/imdario/mergo                            7c29201646fa3de8506f70121347
 golang.org/x/sync                                   e225da77a7e68af35c70ccbf71af2b83e6acac3c
 
 # buildkit
-github.com/moby/buildkit                            ae10b292fefb00e0fbf9fecd1419c5f252e58895
+github.com/moby/buildkit                            ff93519eefb7d4b2ee67dd78166cd5d0f52f8980
 github.com/tonistiigi/fsutil                        3d2716dd0a4d06ff854241c7e8b6f3f904e1719f
 github.com/grpc-ecosystem/grpc-opentracing          8e809c8a86450a29b90dcc9efbf062d0fe6d9746
 github.com/opentracing/opentracing-go               1361b9cd60be79c4c3a7fa9841b3c132e40066a7

--- a/vendor/github.com/moby/buildkit/frontend/dockerfile/dockerfile2llb/convert.go
+++ b/vendor/github.com/moby/buildkit/frontend/dockerfile/dockerfile2llb/convert.go
@@ -1202,31 +1202,13 @@ func normalizeContextPaths(paths map[string]struct{}) []string {
 		if p == "/" {
 			return nil
 		}
-		pathSlice = append(pathSlice, p)
+		pathSlice = append(pathSlice, path.Join(".", p))
 	}
 
-	toDelete := map[string]struct{}{}
-	for i := range pathSlice {
-		for j := range pathSlice {
-			if i == j {
-				continue
-			}
-			if strings.HasPrefix(pathSlice[j], pathSlice[i]+"/") {
-				delete(paths, pathSlice[j])
-			}
-		}
-	}
-
-	toSort := make([]string, 0, len(paths))
-	for p := range paths {
-		if _, ok := toDelete[p]; !ok {
-			toSort = append(toSort, path.Join(".", p))
-		}
-	}
-	sort.Slice(toSort, func(i, j int) bool {
-		return toSort[i] < toSort[j]
+	sort.Slice(pathSlice, func(i, j int) bool {
+		return pathSlice[i] < pathSlice[j]
 	})
-	return toSort
+	return pathSlice
 }
 
 func proxyEnvFromBuildArgs(args map[string]string) *llb.ProxyEnv {

--- a/vendor/github.com/moby/buildkit/session/sshforward/ssh.go
+++ b/vendor/github.com/moby/buildkit/session/sshforward/ssh.go
@@ -75,6 +75,10 @@ func MountSSHSocket(ctx context.Context, c session.Caller, opt SocketOpt) (sockP
 		}
 	}()
 
+	if err := os.Chmod(dir, 0711); err != nil {
+		return "", nil, errors.WithStack(err)
+	}
+
 	sockPath = filepath.Join(dir, "ssh_auth_sock")
 
 	l, err := net.Listen("unix", sockPath)

--- a/vendor/github.com/moby/buildkit/solver/llbsolver/ops/exec.go
+++ b/vendor/github.com/moby/buildkit/solver/llbsolver/ops/exec.go
@@ -525,7 +525,7 @@ func (sm *secretMountInstance) Mount() ([]mount.Mount, func() error, error) {
 	return []mount.Mount{{
 		Type:    "bind",
 		Source:  fp,
-		Options: []string{"ro", "rbind"},
+		Options: []string{"ro", "rbind", "nodev", "nosuid", "noexec"},
 	}}, cleanup, nil
 }
 


### PR DESCRIPTION
https://github.com/moby/buildkit/pull/1243

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>

changelog line:
```
- Fix builder-next: permission errors on using build secrets or ssh forwarding with userns-remap.
- Fix builder-next: copying a symlink inside an already copied directory.
```
