### PR TITLE
[19.03 backport] update containerd binary v1.3.0

### DIFF
--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-CONTAINERD_COMMIT=b34a5c8af56e510852c35414db4c1f4fa6172339 # v1.2.10
+CONTAINERD_COMMIT=36cf5b690dcc00ff0f34ff7799209050c3d0c59a # v1.3.0
 
 install_containerd() {
 	echo "Install containerd version $CONTAINERD_COMMIT"

--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -4,7 +4,7 @@
 # containerd is also pinned in vendor.conf. When updating the binary
 # version you may also need to update the vendor version to pick up bug
 # fixes or new APIs.
-CONTAINERD_COMMIT=f772c10a585ced6be8f86e8c58c2b998412dd963 # v1.2.11
+CONTAINERD_COMMIT=b34a5c8af56e510852c35414db4c1f4fa6172339 # v1.2.10
 
 install_containerd() {
 	echo "Install containerd version $CONTAINERD_COMMIT"


### PR DESCRIPTION
cherry-picking the containerd v1.3.0 (binary) bump to 19.03, taken from https://github.com/moby/moby/pull/39713

this is to see if integration tests work fine if we would update the existing 19.03 version to the latest containerd

full diff: https://github.com/containerd/containerd/compare/v1.2.10..v1.3.0

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>
Signed-off-by: Derek McGowan <derek@mcgstyle.net>
(cherry picked from commit 6c94a50f4198fffa44f93d627044f1ca43545081)
Signed-off-by: Sebastiaan van Stijn <github@gone.nl>

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

