### PR TITLE
[19.03] vendor: update buildkit to 928f3b48

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -26,7 +26,7 @@ github.com/imdario/mergo                            7c29201646fa3de8506f70121347
 golang.org/x/sync                                   e225da77a7e68af35c70ccbf71af2b83e6acac3c
 
 # buildkit
-github.com/moby/buildkit                            ff93519eefb7d4b2ee67dd78166cd5d0f52f8980
+github.com/moby/buildkit                            928f3b480d7460aacb401f68610058ffdb549aca
 github.com/tonistiigi/fsutil                        3d2716dd0a4d06ff854241c7e8b6f3f904e1719f
 github.com/grpc-ecosystem/grpc-opentracing          8e809c8a86450a29b90dcc9efbf062d0fe6d9746
 github.com/opentracing/opentracing-go               1361b9cd60be79c4c3a7fa9841b3c132e40066a7

--- a/vendor/github.com/moby/buildkit/cache/refs.go
+++ b/vendor/github.com/moby/buildkit/cache/refs.go
@@ -185,7 +185,10 @@ func (cr *cacheRecord) Mount(ctx context.Context, readonly bool) (snapshot.Mount
 func (cr *cacheRecord) remove(ctx context.Context, removeSnapshot bool) error {
 	delete(cr.cm.records, cr.ID())
 	if cr.parent != nil {
-		if err := cr.parent.release(ctx); err != nil {
+		cr.parent.mu.Lock()
+		err := cr.parent.release(ctx)
+		cr.parent.mu.Unlock()
+		if err != nil {
 			return err
 		}
 	}
@@ -398,11 +401,6 @@ func (sr *mutableRef) release(ctx context.Context) error {
 				return nil
 			}
 			if err := sr.equalImmutable.remove(ctx, false); err != nil {
-				return err
-			}
-		}
-		if sr.parent != nil {
-			if err := sr.parent.release(ctx); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
Brings in:
https://github.com/moby/buildkit/pull/1257 cache: fix possible concurrent maps write on parent release

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>
