### PR TITLE
[19.03 backport] Windows: Use system specific parallelism value on containers restart

### DIFF
--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -3,7 +3,9 @@ package daemon // import "github.com/docker/docker/daemon"
 import (
 	"context"
 	"fmt"
+	"math"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/Microsoft/hcsshim"
@@ -40,9 +42,10 @@ const (
 	windowsMaxCPUPercent = 100
 )
 
-// Windows doesn't really have rlimits.
+// Windows containers are much larger than Linux containers and each of them
+// have > 20 system processes which why we use much smaller parallelism value.
 func adjustParallelLimit(n int, limit int) int {
-	return limit
+	return int(math.Max(1, math.Floor(float64(runtime.NumCPU())*.8)))
 }
 
 // Windows has no concept of an execution state directory. So use config.Root here.


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/39733

**- What I did**
#38301 did set container restart/restore task parallelism limit to 128*NumCPU which is good limit for Linux containers. Especially when they are made correctly by following one process per container rule.

However Windows containers are much heavier and example Windows Server 2019 base image `mcr.microsoft.com/windows/servercore:ltsc2019` it selves includes ~20 system processes which causes restoring to generate so high load to server and it cannot response anything else until restore is completed.

**- How I did it**
Disabled restore parallelism from Windows platform.

**- How to verify it**
I created 100 containers with restart policy:
```powershell
for($i=1;$i -le 100;$i++) {
	docker run -d --restart always --network nat mcr.microsoft.com/windows/servercore:ltsc2019 ping -t 127.0.0.1
	start-sleep -seconds 10
}
```
 On my 4 CPU test machine it they take about 8 minutes to restart with and without this changes.
However there is big difference how server is able to response to other commands.

Without this change CPU load is constantly 100% and even typing text to notepad takes long time: 
![without_patch_restore](https://user-images.githubusercontent.com/6213926/62940803-0755db00-bddd-11e9-9416-fc53846e64c9.png)

After this change server still uses all CPU it have now it still responses to user input.
![docker_restart_parallel_1](https://user-images.githubusercontent.com/6213926/62940759-eb523980-bddc-11e9-986b-37231570e12a.PNG)

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/6213926/62940983-89460400-bddd-11e9-9748-988d12d182a1.png)
