### PR TITLE
[19.03 backport] daemon: Use short libnetwork ID in exec-root & update libnetwork

### DIFF
--- a/builder/builder-next/executor_unix.go
+++ b/builder/builder-next/executor_unix.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/docker/docker/daemon/config"
 	"github.com/docker/docker/pkg/idtools"
+	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/libnetwork"
 	"github.com/moby/buildkit/executor"
 	"github.com/moby/buildkit/executor/oci"
@@ -100,11 +101,12 @@ func (iface *lnInterface) Set(s *specs.Spec) {
 		logrus.WithError(iface.err).Error("failed to set networking spec")
 		return
 	}
+	shortNetCtlrID := stringid.TruncateID(iface.provider.NetworkController.ID())
 	// attach netns to bridge within the container namespace, using reexec in a prestart hook
 	s.Hooks = &specs.Hooks{
 		Prestart: []specs.Hook{{
 			Path: filepath.Join("/proc", strconv.Itoa(os.Getpid()), "exe"),
-			Args: []string{"libnetwork-setkey", "-exec-root=" + iface.provider.Config().Daemon.ExecRoot, iface.sbx.ContainerID(), iface.provider.NetworkController.ID()},
+			Args: []string{"libnetwork-setkey", "-exec-root=" + iface.provider.Config().Daemon.ExecRoot, iface.sbx.ContainerID(), shortNetCtlrID},
 		}},
 	}
 }

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -20,6 +20,7 @@ import (
 	"github.com/docker/docker/oci/caps"
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/pkg/mount"
+	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/docker/rootless/specconv"
 	volumemounts "github.com/docker/docker/volume/mounts"
 	"github.com/opencontainers/runc/libcontainer/apparmor"
@@ -66,13 +67,14 @@ func WithLibnetwork(daemon *Daemon, c *container.Container) coci.SpecOpts {
 		for _, ns := range s.Linux.Namespaces {
 			if ns.Type == "network" && ns.Path == "" && !c.Config.NetworkDisabled {
 				target := filepath.Join("/proc", strconv.Itoa(os.Getpid()), "exe")
+				shortNetCtlrID := stringid.TruncateID(daemon.netController.ID())
 				s.Hooks.Prestart = append(s.Hooks.Prestart, specs.Hook{
 					Path: target,
 					Args: []string{
 						"libnetwork-setkey",
 						"-exec-root=" + daemon.configStore.GetExecRoot(),
 						c.ID,
-						daemon.netController.ID(),
+						shortNetCtlrID,
 					},
 				})
 			}

--- a/hack/dockerfile/install/proxy.installer
+++ b/hack/dockerfile/install/proxy.installer
@@ -3,7 +3,7 @@
 # LIBNETWORK_COMMIT is used to build the docker-userland-proxy binary. When
 # updating the binary version, consider updating github.com/docker/libnetwork
 # in vendor.conf accordingly
-LIBNETWORK_COMMIT=3eb39382bfa6a3c42f83674ab080ae13b0e34e5d # bump_19.03 branch
+LIBNETWORK_COMMIT=d9a6682a4dbb13b1f0d8216c425fe9ae010a0f23 # bump_19.03 branch
 
 install_proxy() {
 	case "$1" in

--- a/vendor.conf
+++ b/vendor.conf
@@ -38,7 +38,7 @@ github.com/gofrs/flock                              7f43ea2e6a643ad441fc12d0ecc0
 # libnetwork
 
 # When updating, also update LIBNETWORK_COMMIT in hack/dockerfile/install/proxy.installer accordingly
-github.com/docker/libnetwork                        3eb39382bfa6a3c42f83674ab080ae13b0e34e5d # bump_19.03 branch
+github.com/docker/libnetwork                        d9a6682a4dbb13b1f0d8216c425fe9ae010a0f23 # bump_19.03 branch
 github.com/docker/go-events                         9461782956ad83b30282bf90e31fa6a70c255ba9
 github.com/armon/go-radix                           e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics                         eb0af217e5e9747e41dd5303755356b62d28e3ec

--- a/vendor/github.com/docker/libnetwork/drivers/overlay/overlay.go
+++ b/vendor/github.com/docker/libnetwork/drivers/overlay/overlay.go
@@ -378,7 +378,7 @@ func (d *driver) DiscoverNew(dType discoverapi.DiscoveryType, data interface{}) 
 			}
 		}
 		if err := d.updateKeys(newKey, priKey, delKey); err != nil {
-			logrus.Warn(err)
+			return err
 		}
 	default:
 	}


### PR DESCRIPTION
backport of:

- https://github.com/moby/moby/pull/39822 daemon: Use short libnetwork ID in exec-root
- https://github.com/docker/libnetwork/pull/2482 [19.03 backport] Shorten controller ID in exec-root to not hit UNIX_PATH_MAX
    - backports https://github.com/docker/libnetwork/pull/2443 Shorten controller ID in exec-root to not hit UNIX_PATH_MAX
- https://github.com/docker/libnetwork/pull/2483 [19.03 backport] Fix panic in drivers/overlay/encryption.go
    - backports: https://github.com/docker/libnetwork/pull/2462 Fix panic in drivers/overlay/encryption.go

Relates to / addresses: https://github.com/moby/moby/issues/39608 Upgrade to 19.03 from 18 results in libnetwork-setkey hitting UNIX_PATH_MAX limit