### PR TITLE
[19.03] Windows: Only set VERSION_QUAD if unset

### DIFF
--- a/hack/make/.go-autogen
+++ b/hack/make/.go-autogen
@@ -58,7 +58,9 @@ if [ "$(go env GOOS)" = "windows" ]; then
 	fi
 
 	# Generate a Windows file version of the form major,minor,patch,build (with any part optional)
-	VERSION_QUAD=$(echo -n $VERSION | sed -re 's/^([0-9.]*).*$/\1/' | tr . ,)
+	if [ ! -v VERSION_QUAD ]; then
+		VERSION_QUAD=$(echo -n $VERSION | sed -re 's/^([0-9.]*).*$/\1/' | tr . ,)
+	fi
 
 	# Pass version and commit information into the resource compiler
 	defs=


### PR DESCRIPTION
When trying to build with some pretty typical version strings this was
causing failures trying to generate the windows resource file.

The resource file is already gated by an `ifdef` for this var, so
instead of blindly setting based on "VERSION", which can contain some
characters which are incompatible (e.g. 1.2.3.rc.0 will fail due to the
".rc").

Signed-off-by: Brian Goff <cpuguy83@gmail.com>
(cherry picked from commit ce931f28ea8768baa7ca2725d9030fbf8a40d3ba)
Signed-off-by: Brian Goff <cpuguy83@gmail.com>

Backports moby/moby#40169