### PR TITLE
Allow client consumers like traefik to compile on illumos

### DIFF
--- a/client/client_unix.go
+++ b/client/client_unix.go
@@ -1,4 +1,4 @@
-// +build linux freebsd openbsd darwin
+// +build linux freebsd openbsd darwin solaris illumos
 
 package client // import "github.com/docker/docker/client"
 


### PR DESCRIPTION
This is not especially useful seeing that illumos has no docker daemon but the client code is not dependent on actually running the daemon on the same host and some clients also include third party software like traefik which otherwise will not compile.

Also a cute animal picture as requested :)
![illumos](https://illumos.org/docs/images/logo/Phoenix64x64-RGB.png)