### PR TITLE
[19.03 backport] logger/gelf: Skip empty lines to comply with spec

### DIFF
--- a/daemon/logger/gelf/gelf.go
+++ b/daemon/logger/gelf/gelf.go
@@ -166,6 +166,10 @@ func newGELFUDPWriter(address string, info logger.Info) (gelf.Writer, error) {
 }
 
 func (s *gelfLogger) Log(msg *logger.Message) error {
+	if len(msg.Line) == 0 {
+		return nil
+	}
+
 	level := gelf.LOG_INFO
 	if msg.Source == "stderr" {
 		level = gelf.LOG_ERR


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/40234 for 19.03

The [gelf payload specification](http://docs.graylog.org/en/2.4/pages/gelf.html#gelf-payload-specification) demands that the field `short_message` *MUST* be set by the client library.
Since docker logging via the gelf driver sends messages line by line, it can happen that messages with an empty `short_message` are passed on. This causes strict downstream processors (like graylog) to raise an exception.

The logger now replaces message lines of length zero with the content `<empty-line>`. This is done
for the following reasons:

- Keeps it possible to reconstruct the logging output in its entirety
- Does not break logging setups that need the information from empty logs (e.g. Logstash rules)

fixes https://github.com/moby/moby/issues/40232 Logging driver for GELF sends message with empty mandatory field "short_message"
fixes https://github.com/moby/moby/issues/37572 Gelf logdriver: empty lines not allowed by spec

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```Markdown
* Fix Gelf logdriver: empty lines not allowed by spec
```
