### PR TITLE
[19.03 backport] cast Dev and Rdev of Stat_t to uint64 for mips

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -193,8 +193,9 @@ func getBlkioWeightDevices(config containertypes.Resources) ([]specs.LinuxWeight
 		}
 		weight := weightDevice.Weight
 		d := specs.LinuxWeightDevice{Weight: &weight}
-		d.Major = int64(unix.Major(stat.Rdev))
-		d.Minor = int64(unix.Minor(stat.Rdev))
+		// The type is 32bit on mips.
+		d.Major = int64(unix.Major(uint64(stat.Rdev))) // nolint: unconvert
+		d.Minor = int64(unix.Minor(uint64(stat.Rdev))) // nolint: unconvert
 		blkioWeightDevices = append(blkioWeightDevices, d)
 	}
 
@@ -264,8 +265,9 @@ func getBlkioThrottleDevices(devs []*blkiodev.ThrottleDevice) ([]specs.LinuxThro
 			return nil, err
 		}
 		d := specs.LinuxThrottleDevice{Rate: d.Rate}
-		d.Major = int64(unix.Major(stat.Rdev))
-		d.Minor = int64(unix.Minor(stat.Rdev))
+		// the type is 32bit on mips
+		d.Major = int64(unix.Major(uint64(stat.Rdev))) // nolint: unconvert
+		d.Minor = int64(unix.Minor(uint64(stat.Rdev))) // nolint: unconvert
 		throttleDevices = append(throttleDevices, d)
 	}
 

--- a/daemon/graphdriver/copy/copy.go
+++ b/daemon/graphdriver/copy/copy.go
@@ -146,7 +146,8 @@ func DirCopy(srcDir, dstDir string, copyMode Mode, copyXattrs bool) error {
 
 		switch mode := f.Mode(); {
 		case mode.IsRegular():
-			id := fileID{dev: stat.Dev, ino: stat.Ino}
+			//the type is 32bit on mips
+			id := fileID{dev: uint64(stat.Dev), ino: stat.Ino} // nolint: unconvert
 			if copyMode == Hardlink {
 				isHardlink = true
 				if err2 := os.Link(srcPath, dstPath); err2 != nil {

--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -1527,7 +1527,8 @@ func getDeviceMajorMinor(file *os.File) (uint64, uint64, error) {
 		return 0, 0, err
 	}
 
-	dev := stat.Rdev
+	// the type is 32bit on mips
+	dev := uint64(stat.Rdev) // nolint: unconvert
 	majorNum := major(dev)
 	minorNum := minor(dev)
 
@@ -1738,7 +1739,8 @@ func (devices *DeviceSet) initDevmapper(doInit bool) (retErr error) {
 	//	- Managed by docker
 	//	- The target of this device is at major <maj> and minor <min>
 	//	- If <inode> is defined, use that file inside the device as a loopback image. Otherwise use the device itself.
-	devices.devicePrefix = fmt.Sprintf("docker-%d:%d-%d", major(st.Dev), minor(st.Dev), st.Ino)
+	// The type Dev in Stat_t is 32bit on mips.
+	devices.devicePrefix = fmt.Sprintf("docker-%d:%d-%d", major(uint64(st.Dev)), minor(uint64(st.Dev)), st.Ino) // nolint: unconvert
 	logger.Debugf("Generated prefix: %s", devices.devicePrefix)
 
 	// Check for the existence of the thin-pool device

--- a/pkg/loopback/loopback.go
+++ b/pkg/loopback/loopback.go
@@ -37,7 +37,8 @@ func FindLoopDeviceFor(file *os.File) *os.File {
 		return nil
 	}
 	targetInode := stat.Ino
-	targetDevice := stat.Dev
+	// the type is 32bit on mips
+	targetDevice := uint64(stat.Dev) // nolint: unconvert
 
 	for i := 0; true; i++ {
 		path := fmt.Sprintf("/dev/loop%d", i)

--- a/pkg/system/stat_linux.go
+++ b/pkg/system/stat_linux.go
@@ -8,7 +8,8 @@ func fromStatT(s *syscall.Stat_t) (*StatT, error) {
 		mode: s.Mode,
 		uid:  s.Uid,
 		gid:  s.Gid,
-		rdev: s.Rdev,
+		// the type is 32bit on mips
+		rdev: uint64(s.Rdev), // nolint: unconvert
 		mtim: s.Mtim}, nil
 }
 


### PR DESCRIPTION
(cherry picked from commit 5f0231bca193320e1a3d785a3ade0e64241fe580)
Signed-off-by: Dominic Yin <yindongchao@inspur.com>

backport of https://github.com/moby/moby/pull/39646

fixed compiling errors on mips architecture

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
This PR fixed build errors about like "cannot use s.Rdev (type uint32) as type uint64" when targeting mips due to the Dev and Rdev in Stat_t being 32-bit on 32-bit mips.

**- How I did it**
Inserted casts to uint64 where needed.

**- How to verify it**
Note that we cannot build docker on mips64le in conventional way, instead we have to run the script directly. After fix some other problems like ztypes and zerrors in golang.org/x/sys, we build docker successfully following these short steps below:

```
git clone -b v18.09.8-ce https://github.com/docker/docker-ce "$GOPATH/src/github.com/docker/"
cd $GOPATH/src/github.com/docker
ln -s $GOPATH/src/github.com/docker/docker-ce/components/engine docker
cd docker
sh -x ./hack/make.sh dynbinary
```

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**
