### PR TITLE
[19.03] Bump 19.03 libnetwork refpoint

### DIFF
--- a/hack/dockerfile/install/proxy.installer
+++ b/hack/dockerfile/install/proxy.installer
@@ -3,7 +3,7 @@
 # LIBNETWORK_COMMIT is used to build the docker-userland-proxy binary. When
 # updating the binary version, consider updating github.com/docker/libnetwork
 # in vendor.conf accordingly
-LIBNETWORK_COMMIT=d9a6682a4dbb13b1f0d8216c425fe9ae010a0f23 # bump_19.03 branch
+LIBNETWORK_COMMIT=9fd385be8302dbe1071a3ce124891893ff27f90f # bump_19.03 branch
 
 install_proxy() {
 	case "$1" in

--- a/vendor.conf
+++ b/vendor.conf
@@ -38,7 +38,7 @@ github.com/gofrs/flock                              7f43ea2e6a643ad441fc12d0ecc0
 # libnetwork
 
 # When updating, also update LIBNETWORK_COMMIT in hack/dockerfile/install/proxy.installer accordingly
-github.com/docker/libnetwork                        d9a6682a4dbb13b1f0d8216c425fe9ae010a0f23 # bump_19.03 branch
+github.com/docker/libnetwork                        9fd385be8302dbe1071a3ce124891893ff27f90f # bump_19.03 branch
 github.com/docker/go-events                         9461782956ad83b30282bf90e31fa6a70c255ba9
 github.com/armon/go-radix                           e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics                         eb0af217e5e9747e41dd5303755356b62d28e3ec

--- a/vendor/github.com/docker/libnetwork/drivers/bridge/setup_device.go
+++ b/vendor/github.com/docker/libnetwork/drivers/bridge/setup_device.go
@@ -35,18 +35,17 @@ func setupDevice(config *networkConfiguration, i *bridgeInterface) error {
 		setMac = kv.Kernel > 3 || (kv.Kernel == 3 && kv.Major >= 3)
 	}
 
+	if setMac {
+		hwAddr := netutils.GenerateRandomMAC()
+		i.Link.Attrs().HardwareAddr = hwAddr
+		logrus.Debugf("Setting bridge mac address to %s", hwAddr)
+	}
+
 	if err = i.nlh.LinkAdd(i.Link); err != nil {
 		logrus.Debugf("Failed to create bridge %s via netlink. Trying ioctl", config.BridgeName)
 		return ioctlCreateBridge(config.BridgeName, setMac)
 	}
 
-	if setMac {
-		hwAddr := netutils.GenerateRandomMAC()
-		if err = i.nlh.LinkSetHardwareAddr(i.Link, hwAddr); err != nil {
-			return fmt.Errorf("failed to set bridge mac-address %s : %s", hwAddr, err.Error())
-		}
-		logrus.Debugf("Setting bridge mac address to %s", hwAddr)
-	}
 	return err
 }
 


### PR DESCRIPTION
full diff: https://github.com/docker/libnetwork/compare/d9a6682a4dbb13b1f0d8216c425fe9ae010a0f23...9fd385be8302dbe1071a3ce124891893ff27f90f

- https://github.com/docker/libnetwork/pull/2495 [19.03 backport] bridge: Fix hwaddr set race between us and udev
    - backport of https://github.com/docker/libnetwork/pull/2380