### PR TITLE
[19.03 backport] Remove cocky from names-generator

### DIFF
--- a/pkg/namesgenerator/names-generator.go
+++ b/pkg/namesgenerator/names-generator.go
@@ -22,7 +22,6 @@ var (
 		"busy",
 		"charming",
 		"clever",
-		"cocky",
 		"cool",
 		"compassionate",
 		"competent",


### PR DESCRIPTION
Could be misinterpreted as something not too kosher

backport of https://github.com/moby/moby/pull/39455
fixes https://github.com/moby/moby/issues/39451 Unfortunate name combo

