### PR TITLE
[19.03 backport] daemon: don't listen on the same address multiple times

### DIFF
--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -608,11 +608,17 @@ func newAPIServerConfig(cli *DaemonCli) (*apiserver.Config, error) {
 
 func loadListeners(cli *DaemonCli, serverConfig *apiserver.Config) ([]string, error) {
 	var hosts []string
+	seen := make(map[string]struct{}, len(cli.Config.Hosts))
+
 	for i := 0; i < len(cli.Config.Hosts); i++ {
 		var err error
 		if cli.Config.Hosts[i], err = dopts.ParseHost(cli.Config.TLS, honorXDG, cli.Config.Hosts[i]); err != nil {
 			return nil, errors.Wrapf(err, "error parsing -H %s", cli.Config.Hosts[i])
 		}
+		if _, ok := seen[cli.Config.Hosts[i]]; ok {
+			continue
+		}
+		seen[cli.Config.Hosts[i]] = struct{}{}
 
 		protoAddr := cli.Config.Hosts[i]
 		protoAddrParts := strings.SplitN(protoAddr, "://", 2)


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/39514

see https://github.com/moby/moby/pull/39454#issuecomment-511054056

Before this change:

    dockerd -H unix:///run/docker.sock -H unix:///run/docker.sock -H unix:///run/docker.sock
    ...
    INFO[2019-07-13T00:02:36.195090937Z] Daemon has completed initialization
    INFO[2019-07-13T00:02:36.215940441Z] API listen on /run/docker.sock
    INFO[2019-07-13T00:02:36.215933172Z] API listen on /run/docker.sock
    INFO[2019-07-13T00:02:36.215990566Z] API listen on /run/docker.sock

After this change:

    dockerd -H unix:///run/docker.sock -H unix:///run/docker.sock -H unix:///run/docker.sock
    ...
    INFO[2019-07-13T00:01:37.533579874Z] Daemon has completed initialization
    INFO[2019-07-13T00:01:37.567045771Z] API listen on /run/docker.sock


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
