### PR TITLE
[19.03 backport] Avoid a data race in container/health.go

### DIFF
--- a/container/health.go
+++ b/container/health.go
@@ -22,7 +22,7 @@ func (s *Health) String() string {
 	case types.Starting:
 		return "health: starting"
 	default: // Healthy and Unhealthy are clear on their own
-		return s.Health.Status
+		return status
 	}
 }
 


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/39645
Fixes https://github.com/moby/moby/issues/39503


**- What I did**
Use a local variable `status` instead of `s.Health.Status` as the return variable of function `(Health).String`, in order to avoid potential data race.

Besides potential data race, I think the old code has another problem: if `s.Health.Status` is "", then the old `(Health).String` will return "", but this is inconsistent with `(Health).Status`, which will return `types.Unhealthy`. After my commit, the return value of `(Health).String` will be consistent with `(Health).Status`.


**- How to verify it**
All read/write operations to `s.Health.Status` is protected by `s.mu.Lock()`, except this one in `(Health).String`. So I suppose this read operation without critical section would cause data race.

I can only find one usage of `(Health).String`, as shown below. I think my patch will not affect other behavior of this project.
```Go
// String returns a human-readable description of the state
func (s *State) String() string {
	if s.Running {
		...
		if h := s.Health; h != nil {
			return fmt.Sprintf("Up %s (%s)", units.HumanDuration(time.Now().UTC().Sub(s.StartedAt)), h.String())
		}
		...
	}
```

**- Description for the changelog**
\#\#\#Bug fixes
\- Fix a potential data race in `(Health).String`.
\- Now `(Health).String` will return `types.Unhealthy`, if `s.Health.Status` is "".

