### PR TITLE
[19.03 backport] pkg/parsers/kernel: gofmt hex value (preparation for Go 1.13+)

### DIFF
--- a/pkg/parsers/kernel/kernel_windows.go
+++ b/pkg/parsers/kernel/kernel_windows.go
@@ -44,7 +44,7 @@ func GetKernelVersion() (*VersionInfo, error) {
 	}
 
 	KVI.major = int(dwVersion & 0xFF)
-	KVI.minor = int((dwVersion & 0XFF00) >> 8)
+	KVI.minor = int((dwVersion & 0xFF00) >> 8)
 	KVI.build = int((dwVersion & 0xFFFF0000) >> 16)
 
 	return KVI, nil


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/39883
relates to https://github.com/moby/moby/pull/39549