### PR TITLE
[19.03 backport] Move GOPATH out from under the GO source tree

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -45,8 +45,8 @@
 #
 # 1. Clone the sources from github.com:
 #
-#    >>   git clone https://github.com/docker/docker.git C:\go\src\github.com\docker\docker
-#    >>   Cloning into 'C:\go\src\github.com\docker\docker'...
+#    >>   git clone https://github.com/docker/docker.git C:\gopath\src\github.com\docker\docker
+#    >>   Cloning into 'C:\gopath\src\github.com\docker\docker'...
 #    >>   remote: Counting objects: 186216, done.
 #    >>   remote: Compressing objects: 100% (21/21), done.
 #    >>   remote: Total 186216 (delta 5), reused 0 (delta 0), pack-reused 186195
@@ -59,7 +59,7 @@
 #
 # 2. Change directory to the cloned docker sources:
 #
-#    >>   cd C:\go\src\github.com\docker\docker 
+#    >>   cd C:\gopath\src\github.com\docker\docker 
 #
 #
 # 3. Build a docker image with the components required to build the docker binaries from source
@@ -79,8 +79,8 @@
 # 5. Copy the binaries out of the container, replacing HostPath with an appropriate destination 
 #    folder on the host system where you want the binaries to be located.
 #
-#    >>   docker cp binaries:C:\go\src\github.com\docker\docker\bundles\docker.exe C:\HostPath\docker.exe
-#    >>   docker cp binaries:C:\go\src\github.com\docker\docker\bundles\dockerd.exe C:\HostPath\dockerd.exe
+#    >>   docker cp binaries:C:\gopath\src\github.com\docker\docker\bundles\docker.exe C:\HostPath\docker.exe
+#    >>   docker cp binaries:C:\gopath\src\github.com\docker\docker\bundles\dockerd.exe C:\HostPath\dockerd.exe
 #
 #
 # 6. (Optional) Remove the interim container holding the built executable binaries:
@@ -172,7 +172,7 @@ ARG GO_VERSION=1.12.14
 #  - FROM_DOCKERFILE is used for detection of building within a container.
 ENV GO_VERSION=${GO_VERSION} `
     GIT_VERSION=2.11.1 `
-    GOPATH=C:\go `
+    GOPATH=C:\gopath `
     FROM_DOCKERFILE=1
 
 RUN `
@@ -249,7 +249,7 @@ RUN `
   Remove-Item C:\gitsetup.zip; `
   `
   Write-Host INFO: Creating source directory...; `
-  New-Item -ItemType Directory -Path C:\go\src\github.com\docker\docker | Out-Null; `
+  New-Item -ItemType Directory -Path ${GOPATH}\src\github.com\docker\docker | Out-Null; `
   `
   Write-Host INFO: Configuring git core.autocrlf...; `
   C:\git\cmd\git config --global core.autocrlf true; `
@@ -260,7 +260,7 @@ RUN `
 ENTRYPOINT ["powershell.exe"]
 
 # Set the working directory to the location of the sources
-WORKDIR C:\go\src\github.com\docker\docker
+WORKDIR ${GOPATH}\src\github.com\docker\docker
 
 # Copy the sources into the container
 COPY . .

--- a/docs/contributing/software-req-win.md
+++ b/docs/contributing/software-req-win.md
@@ -100,8 +100,8 @@ To build Moby, run:
 Copy out the resulting Windows Moby Engine binary to `dockerd.exe` in the
 current directory:
 
-    docker cp binaries:C:\go\src\github.com\docker\docker\bundles\docker.exe docker.exe
-    docker cp binaries:C:\go\src\github.com\docker\docker\bundles\dockerd.exe dockerd.exe
+    docker cp binaries:C:\gopath\src\github.com\docker\docker\bundles\docker.exe docker.exe
+    docker cp binaries:C:\gopath\src\github.com\docker\docker\bundles\dockerd.exe dockerd.exe
 
 To test it, stop the system Docker daemon and start the one you just built:
 
@@ -109,7 +109,7 @@ To test it, stop the system Docker daemon and start the one you just built:
     .\dockerd.exe -D
 
 The other make targets work too, to run unit tests try:
-`docker run --rm docker-builder sh -c 'cd /c/go/src/github.com/docker/docker; hack/make.sh test-unit'`.
+`docker run --rm docker-builder sh -c 'cd /c/gopath/src/github.com/docker/docker; hack/make.sh test-unit'`.
 
 ### 6. Remove the interim binaries container
 

--- a/hack/ci/windows.ps1
+++ b/hack/ci/windows.ps1
@@ -486,7 +486,7 @@ Try {
     }
 
     # Following at the moment must be docker\docker as it's dictated by dockerfile.Windows
-    $contPath="$COMMITHASH`:c`:\go\src\github.com\docker\docker\bundles"
+    $contPath="$COMMITHASH`:c`:\gopath\src\github.com\docker\docker\bundles"
 
     # After https://github.com/docker/docker/pull/30290, .git was added to .dockerignore. Therefore
     # we have to calculate unsupported outside of the container, and pass the commit ID in through
@@ -850,7 +850,7 @@ Try {
                 $Duration= $(Measure-Command { & docker run `
                                                         --rm `
                                                         -e c=$c `
-                                                        --workdir "c`:\go\src\github.com\docker\docker\integration-cli" `
+                                                        --workdir "c`:\gopath\src\github.com\docker\docker\integration-cli" `
                                                         -v "$env:TEMP\binary`:c:\target" `
                                                         docker `
                                                         "`$env`:PATH`='c`:\target;'+`$env:PATH`;  `$env:DOCKER_HOST`='tcp`://'+(ipconfig | select -last 1).Substring(39)+'`:2357'; c:\target\runIntegrationCLI.ps1" | Out-Host } )


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/39888

Unlike Linux which uses a temp dir as GOPATH, Windows
uses c:\go. Among other things, this blocks go get.

Moving GOPATH to c:\gopath and updating references in
comments and documentation.

Currently the change is being scoped narrowly. In the
future GOPATH value could be passed as a parameter to
the ps1 scripts.


