### PR TITLE
[19.03 backport] bump docker-py to 4.1.0

### DIFF
--- a/hack/make/test-docker-py
+++ b/hack/make/test-docker-py
@@ -7,7 +7,7 @@ source hack/make/.integration-test-helpers
 # TODO docker 17.06 cli client used in CI fails to build using a sha;
 # unable to prepare context: unable to 'git clone' to temporary context directory: error fetching: error: no such remote ref ead0bb9e08c13dd3d1712759491eee06bf5a5602
 #: exit status 128
-: "${DOCKER_PY_COMMIT:=master}"
+: "${DOCKER_PY_COMMIT:=4.1.0}"
 
 # custom options to pass py.test
 # TODO remove these skip once we update to a docker-py version that has https://github.com/docker/docker-py/pull/2485


### PR DESCRIPTION
backport of https://github.com/moby/moby/pull/40034
relates to https://github.com/docker/engine/pull/437
