### PR TITLE
[19.03] Bump Golang 1.12.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@
 #
 
 ARG CROSS="false"
-ARG GO_VERSION=1.12.14
+ARG GO_VERSION=1.12.15
 ARG DEBIAN_FRONTEND=noninteractive
 
 FROM golang:${GO_VERSION}-stretch AS base

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.12.14
+ARG GO_VERSION=1.12.15
 
 FROM golang:${GO_VERSION}-alpine AS base
 

--- a/Dockerfile.simple
+++ b/Dockerfile.simple
@@ -5,7 +5,7 @@
 
 # This represents the bare minimum required to build and test Docker.
 
-ARG GO_VERSION=1.12.14
+ARG GO_VERSION=1.12.15
 
 FROM golang:${GO_VERSION}-stretch
 

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -165,7 +165,7 @@ FROM microsoft/windowsservercore
 # Use PowerShell as the default shell
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ARG GO_VERSION=1.12.14
+ARG GO_VERSION=1.12.15
 
 # Environment variable notes:
 #  - GO_VERSION must be consistent with 'Dockerfile' used by Linux.


### PR DESCRIPTION
full diff: https://github.com/golang/go/compare/go1.12.14...go1.12.15

go1.12.15 (released 2020/01/09) includes fixes to the runtime and the net/http
package. See the Go 1.12.15 milestone on the issue tracker for details:

https://github.com/golang/go/issues?q=milestone%3AGo1.12.15+label%3ACherryPickApproved


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

