### PR TITLE
Add support for * for device name in --device

### DIFF
--- a/vendor/github.com/containerd/containerd/oci/utils_unix.go
+++ b/vendor/github.com/containerd/containerd/oci/utils_unix.go
@@ -1,4 +1,3 @@
-//go:build !windows
 // +build !windows
 
 /*
@@ -23,7 +22,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strings"
 
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
@@ -38,24 +36,6 @@ func HostDevices() ([]specs.LinuxDevice, error) {
 }
 
 func getDevices(path, containerPath string) ([]specs.LinuxDevice, error) {
-	// Only wildcard * is supported
-	if strings.HasSuffix(path, "*") {
-		if containerPath != "" {
-			return nil, errors.New("Wildcard device should not have container path")
-		}
-		var out []specs.LinuxDevice
-		devicePaths, _ := filepath.Glob(path)
-		var err error
-		var dev *specs.LinuxDevice
-		for _, devicePath := range devicePaths {
-			dev, err = deviceFromPath(devicePath)
-			if err != nil {
-				return nil, errors.Wrap(err, "error getting device from path")
-			}
-			out = append(out, *dev)
-		}
-		return out, err
-	}
 	stat, err := os.Stat(path)
 	if err != nil {
 		return nil, errors.Wrap(err, "error stating device path")

--- a/vendor/github.com/containerd/containerd/oci/utils_unix.go
+++ b/vendor/github.com/containerd/containerd/oci/utils_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*
@@ -22,6 +23,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
@@ -36,6 +38,24 @@ func HostDevices() ([]specs.LinuxDevice, error) {
 }
 
 func getDevices(path, containerPath string) ([]specs.LinuxDevice, error) {
+	// Only wildcard * is supported
+	if strings.HasSuffix(path, "*") {
+		if containerPath != "" {
+			return nil, errors.New("Wildcard device should not have container path")
+		}
+		var out []specs.LinuxDevice
+		devicePaths, _ := filepath.Glob(path)
+		var err error
+		var dev *specs.LinuxDevice
+		for _, devicePath := range devicePaths {
+			dev, err = deviceFromPath(devicePath)
+			if err != nil {
+				return nil, errors.Wrap(err, "error getting device from path")
+			}
+			out = append(out, *dev)
+		}
+		return out, err
+	}
 	stat, err := os.Stat(path)
 	if err != nil {
 		return nil, errors.Wrap(err, "error stating device path")


### PR DESCRIPTION
This takes care of the [issue](https://github.com/docker/cli/issues/2968) from the server side

Signed-off-by: Venky Natham <vrnatham@amazon.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added code to look for * at the end of the device option

**- How I did it**
If it is there then it goes over all the devices that match that device and adds them to the spec.

**- How to verify it**
```
ubuntu@ip-172-31-34-187:~/go/src/github.com/docker/cli$ ./build/docker run -it --device=/dev/neuron* --name tf inf-tf1.15 bash
root@3ba2bf24d3c5:/# ls /dev
console  core  fd  full  mqueue  neuron0  neuron1  neuron2  neuron3  null  ptmx  pts  random  shm  stderr  stdin  stdout  tty  urandom  zero
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
This takes care of the [issue](https://github.com/docker/cli/issues/2968) from the server side


**- A picture of a cute animal (not mandatory but encouraged)**

